### PR TITLE
fix: guard price snapshot and add dashboard tracing

### DIFF
--- a/key.env
+++ b/key.env
@@ -299,6 +299,11 @@ DASHBOARD_SORT=by_notional        # by_notional | by_upnl | by_symbol
 UPNL_PRICE_SOURCE=last            # last|mid|mark (실제 계산은 safe_price_hint()로 1m 가드 적용)
 
 ########################################
+# DASH 트레이싱(루트원인 확인용)
+########################################
+DASH_TRACE=1   # 1=트레이스/스택/단언 활성화, 0=비활성
+
+########################################
 # (하단) 시크릿/토큰 구역 — 별도 파일 또는 .env 하단 보관 권장
 # * 절대 따옴표(") 붙이지 말고, 공백/한글/이모지 섞지 마세요 (ASCII 만!)
 # BINANCE_API_KEY=


### PR DESCRIPTION
## Summary
- guard `safe_price_hint` against missing snapshots and clamp using 1m candle
- hydrate open positions and unify async dashboard rendering
- protect presence update when statistics dict is missing
- expose dashboard root causes via `DASH_TRACE` stack traces and type assertions
- normalize MAE/MFE state file and assert dict shape when updating stats

## Testing
- `python -m py_compile signal_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ef1b6514832da06878093c210bc1