### PR TITLE
Attach struct overlays and fix timestamp ambiguity

### DIFF
--- a/signal_bot.py
+++ b/signal_bot.py
@@ -508,12 +508,23 @@ def _rows_to_df(rows):
 
 
     cols = [c for c in ["ts","time","open","high","low","close","volume","timestamp"] if c in df.columns]
+    # ensure index doesn't carry 'timestamp' name to avoid ambiguity with the column
+    try:
+        df.index.name = None
+    except Exception:
+        pass
     return df[cols]
 
 def _log_panel_source(symbol: str, tf: str, rows_or_df):
     try:
         df = _rows_to_df(rows_or_df)
-        df = df.sort_values('timestamp') if 'timestamp' in df.columns else df
+        # prefer numeric 'ts' if present; else fall back to 'timestamp'; else index
+        if 'ts' in df.columns:
+            df = df.sort_values('ts')
+        elif 'timestamp' in df.columns:
+            df = df.sort_values('timestamp')
+        else:
+            df = df.sort_index()
 
         if len(df) == 0:
             log(f"[PANEL_SOURCE] {symbol} {tf} len=0")
@@ -11273,23 +11284,25 @@ async def _send_report_oldstyle(client, channel, symbol: str, tf: str):
     # 차트/리포트 산출물
     async with RENDER_SEMA:
         _log_panel_source(symbol, tf, df)
-        chart_files        = await asyncio.to_thread(save_chart_groups, df, symbol, tf)           # 4장
-        # === [PATCH] 구조 오버레이 near/macro 2장 생성 & 첨부(앞쪽) ===
+        chart_files = await asyncio.to_thread(save_chart_groups, df, symbol, tf)  # 4장
+        # === [STRUCT_OVERLAY_FOR_OLDSTYLE] attach Near/Macro first ===
         try:
             rows_struct = _load_ohlcv_rows(symbol, tf, limit=400)
-            df_struct   = _rows_to_df(rows_struct) if rows_struct else None
+            df_struct = _rows_to_df(rows_struct)
         except Exception:
             rows_struct, df_struct = [], None
         if (not rows_struct) and (df is not None) and (len(df) >= env_int("SCE_MIN_ROWS", 60)):
-            # 안전 폴백: 현재 df 사용
             rows_struct = df[['ts','open','high','low','close','volume']].values.tolist() if hasattr(df, 'values') else []
-            df_struct   = _rows_to_df(rows_struct)
+            df_struct = _rows_to_df(rows_struct)
+
         struct_imgs = []
+        struct_info = None
         try:
-            if df_struct is not None and len(df_struct) >= env_int("SCE_MIN_ROWS",60):
+            if df_struct is not None and len(df_struct) >= env_int("SCE_MIN_ROWS", 60):
+                _log_panel_source(symbol, tf, df_struct)
                 struct_info = build_struct_context_basic(df_struct, tf)
                 lb = _tf_view_lookback(tf)
-                near_img  = render_struct_overlay(
+                near_img = render_struct_overlay(
                     symbol, tf, df_struct, struct_info,
                     lookback_override=lb,
                     anchor_override=env_float("STRUCT_VIEW_ANCHOR", 0.68),
@@ -11297,15 +11310,18 @@ async def _send_report_oldstyle(client, channel, symbol: str, tf: str):
                 )
                 macro_img = render_struct_overlay(
                     symbol, tf, df_struct, struct_info,
-                    lookback_override=int(lb*env_float("STRUCT_VIEW_MACRO_MULT",3.0)),
-                    anchor_override=env_float("STRUCT_VIEW_ANCHOR_MACRO",0.85),
+                    lookback_override=int(lb*env_float("STRUCT_VIEW_MACRO_MULT", 3.0)),
+                    anchor_override=env_float("STRUCT_VIEW_ANCHOR_MACRO", 0.85),
                     title_suffix="· Macro",
                 )
                 struct_imgs = [p for p in (near_img, macro_img) if p]
+                if struct_info is not None:
+                    _struct_cache_put(symbol, tf, _df_last_ts(df_struct), struct_info, near_img)
                 if struct_imgs:
-                    chart_files = struct_imgs + list(chart_files)  # 구조 2장을 앞에 PREPEND → 총 6장
+                    chart_files = struct_imgs + list(chart_files)
         except Exception as _e:
             log(f"[STRUCT_IMG_WARN] {symbol} {tf} {type(_e).__name__}: {_e}")
+        # === [/STRUCT_OVERLAY_FOR_OLDSTYLE] ===
     score_file         = plot_score_history(symbol, tf)
     perf_file          = analyze_performance_for(symbol, tf)
     performance_file   = generate_performance_stats(tf, symbol=symbol)


### PR DESCRIPTION
## Summary
- Embed structure overlay images (Near & Macro) in timed oldstyle reports and cache them for reuse
- Clear DataFrame index name to avoid 'timestamp' column ambiguity and improve panel source sorting

## Testing
- `python -m pytest`
- `python -m py_compile signal_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac180ab6cc832db26b219cab09de5a