### PR TITLE
feat: add log scale option and tf-aware ticks

### DIFF
--- a/.env
+++ b/.env
@@ -22,5 +22,7 @@ STRUCT_ENABLE=1
 STRUCT_ATR_LEN=14
 STRUCT_NEAR_THR_ATR=0.8
 STRUCT_MAX_LEVELS=6
+# price scale mode for structure overlays: auto|linear|log
+STRUCT_SCALE_MODE=auto
 # (B에서 사용)
 STRUCT_BREAK_CLOSE_ATR=0.2


### PR DESCRIPTION
## Summary
- add price scale transform utilities and configurable STRUCT_SCALE_MODE
- compute regression and fib channels in linear/log space with inverse plotting
- stabilize time axis ticks using TF-specific locators to avoid AutoDateLocator warnings

## Testing
- `python -m py_compile signal_bot.py && echo "py_compile: success"`


------
https://chatgpt.com/codex/tasks/task_e_68ac6299c058832d810a628a058f2a9c