### PR TITLE
Use absolute imports and add module runner

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -1,9 +1,9 @@
 import asyncio
 
-from .config.settings import load_env_chain
-from .exchange.binance_client import BinanceClient
-from .exchange.streams_market import market_stream
-from .exchange.streams_user import user_stream
+from ftm2.config.settings import load_env_chain
+from ftm2.exchange.binance_client import BinanceClient
+from ftm2.exchange.streams_market import market_stream
+from ftm2.exchange.streams_user import user_stream
 
 
 CFG = load_env_chain()

--- a/ftm2/exchange/binance_client.py
+++ b/ftm2/exchange/binance_client.py
@@ -5,8 +5,8 @@ from typing import Any, Dict
 from urllib.parse import urlencode
 import httpx
 
-from ..config.settings import load_env_chain
-from .quantize import ExchangeFilters
+from ftm2.config.settings import load_env_chain
+from ftm2.exchange.quantize import ExchangeFilters
 
 CFG = load_env_chain()
 

--- a/ftm2/exchange/streams_market.py
+++ b/ftm2/exchange/streams_market.py
@@ -1,6 +1,6 @@
 
 import asyncio, json, websockets
-from ..config.settings import load_env_chain
+from ftm2.config.settings import load_env_chain
 CFG = load_env_chain()
 WS_BASE = "wss://fstream.binance.com" if CFG.MODE == "live" else "wss://fstream.binancefuture.com"
 

--- a/ftm2/exchange/streams_user.py
+++ b/ftm2/exchange/streams_user.py
@@ -1,8 +1,8 @@
 
 import asyncio, json, websockets, contextlib
 
-from ..config.settings import load_env_chain
-from .binance_client import BinanceClient
+from ftm2.config.settings import load_env_chain
+from ftm2.exchange.binance_client import BinanceClient
 
 CFG = load_env_chain()
 

--- a/ftm2/notify/discord_bot.py
+++ b/ftm2/notify/discord_bot.py
@@ -1,7 +1,7 @@
 import asyncio
 import discord
 
-from ..config.settings import load_env_chain
+from ftm2.config.settings import load_env_chain
 
 CFG = load_env_chain()
 

--- a/ftm2/risk/position_sizer.py
+++ b/ftm2/risk/position_sizer.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
-from ..config.settings import load_env_chain
-from ..exchange.quantize import ExchangeFilters
+from ftm2.config.settings import load_env_chain
+from ftm2.exchange.quantize import ExchangeFilters
 
 CFG = load_env_chain()
 

--- a/ftm2/strategy/entry_exit.py
+++ b/ftm2/strategy/entry_exit.py
@@ -1,4 +1,4 @@
-from ..config.settings import load_env_chain
+from ftm2.config.settings import load_env_chain
 
 CFG = load_env_chain()
 

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
-from ..exchange.binance_client import BinanceClient
-from ..exchange.quantize import ExchangeFilters
+from ftm2.exchange.binance_client import BinanceClient
+from ftm2.exchange.quantize import ExchangeFilters
 
 
 class OrderRouter:

--- a/run_ftm2.py
+++ b/run_ftm2.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+import runpy
+
+
+if __name__ == "__main__":
+    # 루트 경로를 sys.path 최우선에 보장
+    ROOT = Path(__file__).parent.resolve()
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    # 패키지 모듈을 __main__으로 실행 (python -m ftm2.app 과 동일)
+    runpy.run_module("ftm2.app", run_name="__main__")
+


### PR DESCRIPTION
## Summary
- use absolute package paths in ftm2 modules for consistent imports
- add `run_ftm2.py` runner that executes `ftm2.app` as a module

## Testing
- `python -m py_compile run_ftm2.py ftm2/app.py ftm2/exchange/binance_client.py ftm2/exchange/streams_market.py ftm2/exchange/streams_user.py ftm2/notify/discord_bot.py ftm2/risk/position_sizer.py ftm2/strategy/entry_exit.py ftm2/trade/order_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae75e95990832d84f63b01f26ee80d