### PR TITLE
feat: improve chart rendering and env settings

### DIFF
--- a/ftm2/charts/builder.py
+++ b/ftm2/charts/builder.py
@@ -1,91 +1,71 @@
 # [ANCHOR:M6_CHARTS_BUILDER_POLICY]
-import os, time, glob
+import os
 import matplotlib.pyplot as plt
 
 
-def _ensure_dir(path: str):
-    os.makedirs(path, exist_ok=True)
+def render_analysis_charts(snapshot, out_dir: str) -> list[str]:
+    """간단한 분석 차트 4장 렌더링.
 
-
-def _prune_rotate(dir_path: str, keep: int):
-    files = sorted(glob.glob(os.path.join(dir_path, "*.png")))
-    if len(files) > keep:
-        for f in files[:-keep]:
-            try:
-                os.remove(f)
-            except Exception:
-                pass
-
-
-def _name_overwrite(sym: str, tf: str, panel: int):
-    return f"{sym}_{tf}_current_panel{panel}.png"
-
-
-def _name_rotate(sym: str, tf: str, panel: int):
-    ts = time.strftime("%Y%m%d_%H%M%S")
-    return f"{sym}_{tf}_{ts}_panel{panel}.png"
-
-
-def render_analysis_charts(cfg, snapshot, out_dir: str) -> list[str]:
+    가격 패널 1장(캔들 대신 종가 라인) + EMA/Bollinger 오버레이,
+    RSI/ADX/CCI 패널 각각 1장씩.
     """
-    저장 정책:
-    - overwrite: 고정 파일명으로 덮어쓰기 (폴더에 파일 2개만 유지)
-    - rotate: 타임스탬프 파일명, CHART_KEEP_PER_SYMBOL 만큼만 남기고 자동 삭제
-    - none: 디스크 저장 안 함(Discord 업로드 직전에 temp 파일 쓰고 즉시 삭제하고 싶으면 처리)
-    """
-    tf = "1m"   # 기본 패널 기준 TF
-    sym = snapshot.symbol
-    base_dir = os.path.join(cfg.CHART_DIR, sym.lower(), tf)
-    _ensure_dir(base_dir)
-
-    # 파일명 결정
-    if cfg.CHART_MODE == "overwrite":
-        fn1 = _name_overwrite(sym, tf, 1)
-        fn2 = _name_overwrite(sym, tf, 2)
-    elif cfg.CHART_MODE == "rotate":
-        fn1 = _name_rotate(sym, tf, 1)
-        fn2 = _name_rotate(sym, tf, 2)
-    else:  # none
-        fn1 = _name_overwrite(sym, tf, 1)
-        fn2 = _name_overwrite(sym, tf, 2)
-
-    p1 = os.path.join(base_dir, fn1)
-    p2 = os.path.join(base_dir, fn2)
-
+    sym = getattr(snapshot, "symbol", "UNK")
+    base_dir = os.path.join(out_dir, sym.lower())
+    os.makedirs(base_dir, exist_ok=True)
 
     indicators = getattr(snapshot, "indicators", {}) or {}
-    df = indicators.get(tf)
+    df = indicators.get("15m")
     if df is None:
-        df = indicators.get("main")
-
-
+        df = next(iter(indicators.values()), None)
     if df is None or len(df) == 0:
         return []
 
-    # Panel 1
+    paths: list[str] = []
+
+    price_png = os.path.join(base_dir, f"{sym}_price.png")
     plt.figure()
-    plt.plot(df["close"])
-    for k in ("ema_fast", "ema_slow", "tenkan", "kijun", "kama", "vwap"):
+    plt.plot(df["close"], label="close")
+    for k in ("ema_fast", "ema_slow", "ema50", "ema200"):
         if k in df.columns:
-            plt.plot(df[k])
-    plt.title("Panel 1")
-    plt.savefig(p1)
+            plt.plot(df[k], label=k)
+    if "bb_up" in df.columns and "bb_dn" in df.columns:
+        plt.plot(df["bb_up"], label="bb_up")
+        plt.plot(df["bb_dn"], label="bb_dn")
+    plt.title("Price")
+    plt.legend()
+    plt.savefig(price_png)
     plt.close()
+    paths.append(price_png)
 
-    # Panel 2
+    # RSI panel
+    rsi_png = os.path.join(base_dir, f"{sym}_rsi.png")
     plt.figure()
-    for k in ("rsi", "adx", "cci", "obv"):
-        if k in df.columns:
-            plt.plot(df[k])
-    plt.title("Panel 2")
-    plt.savefig(p2)
+    if "rsi" in df.columns:
+        plt.plot(df["rsi"], label="rsi")
+    plt.title("RSI")
+    plt.savefig(rsi_png)
     plt.close()
+    paths.append(rsi_png)
 
-    # rotate면 프루닝
-    if cfg.CHART_MODE == "rotate":
-        _prune_rotate(base_dir, cfg.CHART_KEEP_PER_SYMBOL)
-    elif cfg.CHART_MODE == "none":
-        pass  # 필요하면 즉시 삭제(Discord 업로드 후)
+    # ADX panel
+    adx_png = os.path.join(base_dir, f"{sym}_adx.png")
+    plt.figure()
+    if "adx" in df.columns:
+        plt.plot(df["adx"], label="adx")
+    plt.title("ADX")
+    plt.savefig(adx_png)
+    plt.close()
+    paths.append(adx_png)
 
-    return [p1, p2]
+    # CCI panel
+    cci_png = os.path.join(base_dir, f"{sym}_cci.png")
+    plt.figure()
+    if "cci" in df.columns:
+        plt.plot(df["cci"], label="cci")
+    plt.title("CCI")
+    plt.savefig(cci_png)
+    plt.close()
+    paths.append(cci_png)
+
+    return paths
 

--- a/ftm2/config/settings.py
+++ b/ftm2/config/settings.py
@@ -22,7 +22,8 @@ class Settings(BaseModel):
     COOLDOWN_S: int = int(os.getenv("COOLDOWN_S", "180"))
     MAX_DIVERGENCE_BPS: int = int(os.getenv("MAX_DIVERGENCE_BPS", "15"))
     # [ANCHOR:M6_SETTINGS_CHART]
-    CHART_TFS: str = os.getenv("CHART_TFS", "15m,4h")
+    # "15m,4h" -> ["15m","4h"]
+    CHART_TFS: list[str] = [s.strip() for s in os.getenv("CHART_TFS", "15m,4h").split(",") if s.strip()]
     CHART_PRICE_OVERLAYS: str = os.getenv("CHART_PRICE_OVERLAYS", "ema50,ema200,bb20_2")
     CHART_PANELS_15m: str = os.getenv("CHART_PANELS_15m", "price,RSI,ROTATE")
     CHART_PANELS_4h: str = os.getenv("CHART_PANELS_4h", "price,ADXDI,ROTATE")
@@ -39,6 +40,7 @@ class Settings(BaseModel):
     CHART_FORCE_N_CYCLES: int = int(os.getenv("CHART_FORCE_N_CYCLES", "10"))
     CHART_FORCE_FIRST_RENDER: bool = os.getenv("CHART_FORCE_FIRST_RENDER", "false").lower() == "true"
     CHART_FINGERPRINT_RESET: bool = os.getenv("CHART_FINGERPRINT_RESET", "false").lower() == "true"
+    CHART_COOLDOWN_S: int = int(os.getenv("CHART_COOLDOWN_S", "0"))
 
 
     # SIGNALS
@@ -218,13 +220,25 @@ def load_env_chain() -> Settings:
     for k in field_names:
         v = os.getenv(k)
         if v is not None:
-            field_values[k] = v
+            if k == "CHART_TFS":
+                field_values[k] = [s.strip() for s in v.split(",") if s.strip()]
+            else:
+                field_values[k] = v
 
     s = Settings(**field_values)
 
     print(
-        f"[ENV][DUMP] ANALYSIS_TF={s.ANALYSIS_TF}  TF_WEIGHTS={s.TF_WEIGHTS}  "
-        f"CHART_TFS={s.CHART_TFS}  CHART_MODE={s.CHART_MODE}"
+        "[ENV][DUMP] "
+        f"LIVE_GUARD_ENABLE={s.LIVE_GUARD_ENABLE} "
+        f"LIVE_CONFIRM_MODE={s.LIVE_CONFIRM_MODE} "
+        f"CONFIRM_TIMEOUT_S={s.CONFIRM_TIMEOUT_S} "
+        f"LIVE_MIN_NOTIONAL_USDT={s.LIVE_MIN_NOTIONAL_USDT} "
+        f"CHART_FORCE_FIRST_RENDER={s.CHART_FORCE_FIRST_RENDER} "
+        f"CHART_MIN_SCORE_DELTA={s.CHART_MIN_SCORE_DELTA} "
+        f"CHART_MIN_DIVERGENCE_BPS={s.CHART_MIN_DIVERGENCE_BPS} "
+        f"CHART_COOLDOWN_S={s.CHART_COOLDOWN_S} "
+        f"CHART_TFS={s.CHART_TFS} "
+        f"CHART_MODE={s.CHART_MODE}"
     )
 
     for k in ["DISCORD_GUILD_ID", "DISCORD_CHANNEL_LOGS", "DISCORD_CHANNEL_TRADES",

--- a/ftm2/notify/discord_bot.py
+++ b/ftm2/notify/discord_bot.py
@@ -2,7 +2,6 @@
 import asyncio, os, traceback, time
 from typing import Optional
 import discord
-from ftm2.charts.registry import render_ready
 from ftm2.signals.dedupe import should_emit
 from ftm2.config.settings import load_env_chain
 from ftm2.notify.discord_views import build_trade_embed
@@ -58,7 +57,7 @@ async def send_signal_to_discord(sym: str, side: str, score: float, reasons: lis
     text = f"{sym} {side} score={score:.1f} reasons={', '.join(reasons or [])}"
     try:
         if _ch_signals:
-            files = [discord.File(img_path)] if img_path and render_ready(img_path) else None
+            files = [discord.File(img_path)] if img_path and os.path.exists(img_path) else None
             await _ch_signals.send(content=f"📡 {text}", files=files)
         else:
             print(f"[SIGNAL][DRY] {text}")
@@ -88,7 +87,7 @@ async def publish_signal(sym: str, side: str, score: float, reasons: list[str], 
     if not emit:
         return
 
-    await send_signal_to_discord(sym, side, score, reasons, img_path if img_path and render_ready(img_path) else None)
+    await send_signal_to_discord(sym, side, score, reasons, img_path if img_path and os.path.exists(img_path) else None)
 
 async def _sender_loop():
     global _ch_logs, _ch_trades, _ch_signals
@@ -189,7 +188,7 @@ async def update_analysis(
     view:     dict 가공본 (텍스트 임베드용)
     """
 
-    from ftm2.charts.registry import should_render
+    from ftm2.charts.registry import render_ready
     from ftm2.charts.builder import render_analysis_charts
 
 
@@ -223,11 +222,11 @@ async def update_analysis(
         return
 
 
-    fp = getattr(snapshot, "fingerprint", None)
-    if not should_render(symbol, fp):
-        print(f"[CHART][SKIP] {symbol}")
+    ready, info = render_ready(snapshot, _cfg)
+    if not ready:
+        print(f"[CHART][SKIP] {symbol} cause={info.get('cause')}")
     else:
-        paths = render_analysis_charts(_cfg, snapshot, _cfg.CHART_DIR)
+        paths = render_analysis_charts(snapshot, _cfg.CHART_DIR)
         if paths:
             print(f"[CHART][RENDER] {symbol} saved={paths}")
 

--- a/ftm2/strategy/score.py
+++ b/ftm2/strategy/score.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """간단한 스냅샷 점수화 로직."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Any, Optional
 
 import pandas as pd
@@ -26,6 +26,8 @@ try:  # pragma: no cover
 except Exception:  # pragma: no cover
     from . import reasons
 
+from ftm2.charts.registry import compute_fingerprint
+
 
 @dataclass
 class Contribution:
@@ -46,6 +48,8 @@ class Snapshot:
     rules: Dict[str, Any]
     plan: Optional[Dict[str, Any]] = None
     trend_state: str = "UNKNOWN"
+    reasons: List[str] = field(default_factory=list)
+    fingerprint: str = ""
 
     # ✅ 과거 코드 호환 (app.py에서 snap.tfs를 쓰는 부분)
     @property
@@ -186,4 +190,5 @@ def score_snapshot(symbol: str, cache: Dict[str, pd.DataFrame], tfs: List[str], 
         plan=None,
         trend_state=trend_state,
     )
+    snap.fingerprint = compute_fingerprint(snap)
     return snap


### PR DESCRIPTION
## Summary
- parse chart timeframes from env into list and expose new chart cooldown option
- add snapshot fingerprinting and render gate with cooldown and thresholds
- generate separate price/indicator chart images from snapshots

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68afe62159d0832db2f792207ac8a1a4