### PR TITLE
feat: add symbol context and safety for filters

### DIFF
--- a/ftm2/analysis/engine.py
+++ b/ftm2/analysis/engine.py
@@ -62,6 +62,8 @@ async def run_analysis_loop(cfg, symbols, market_cache, divergence, on_snapshot)
 
     # [ANCHOR:M6_ENGINE_BOOT] 최초 캔들 부트스트랩
     for sym in symbols:
+        if bx.filters:
+            bx.filters.use(sym)
         cache = market_cache.setdefault(sym, {})
         for tf in tfs:
             df = cache.get(tf)
@@ -75,6 +77,8 @@ async def run_analysis_loop(cfg, symbols, market_cache, divergence, on_snapshot)
         try:
             started = datetime.now(timezone.utc).timestamp()
             for sym in symbols:
+                if bx.filters:
+                    bx.filters.use(sym)
                 cache = market_cache.setdefault(sym, {})
                 for tf in tfs:
                     if _need_more(cache.get(tf), 100):

--- a/ftm2/exchange/quantize.py
+++ b/ftm2/exchange/quantize.py
@@ -8,21 +8,19 @@ class SymbolFilter:
         self.min_notional = Decimal(minNotional)
 
     def q_price(self, px: Decimal) -> Decimal:
-        """Apply PRICE_FILTER tickSize."""
         return (px / self.tick).to_integral_value(rounding=ROUND_DOWN) * self.tick
 
     def q_qty(self, qty: Decimal) -> Decimal:
-        """Apply LOT_SIZE stepSize."""
         return (qty / self.step).to_integral_value(rounding=ROUND_DOWN) * self.step
 
     def min_ok(self, price: Decimal, qty: Decimal) -> bool:
-        """Check MIN_NOTIONAL."""
         return (price * qty) >= self.min_notional
 
 
 class ExchangeFilters:
     def __init__(self, symbol_map: dict[str, SymbolFilter]):
         self.map = symbol_map
+        self._last_symbol: str | None = None
 
     @classmethod
     def from_exchange_info(cls, info: dict) -> "ExchangeFilters":
@@ -31,13 +29,68 @@ class ExchangeFilters:
             sym = s["symbol"]
             pf = next(f for f in s["filters"] if f["filterType"] == "PRICE_FILTER")
             lf = next(f for f in s["filters"] if f["filterType"] == "LOT_SIZE")
-            mn = next(
-                (f for f in s["filters"] if f["filterType"] in ("MIN_NOTIONAL", "NOTIONAL")),
-                None,
-            )
+            mn = next((f for f in s["filters"] if f["filterType"] in ("MIN_NOTIONAL", "NOTIONAL")), None)
             min_notional = (mn or {}).get("notional", (mn or {}).get("minNotional", "0.0"))
             m[sym] = SymbolFilter(pf["tickSize"], lf["stepSize"], min_notional)
         return cls(m)
 
     def for_symbol(self, symbol: str) -> SymbolFilter:
+        self._last_symbol = symbol
         return self.map[symbol]
+
+    def use(self, symbol: str) -> "ExchangeFilters":
+        self._last_symbol = symbol
+        return self
+
+    def _coerce_decimal(self, x) -> Decimal:
+        return x if isinstance(x, Decimal) else Decimal(str(x))
+
+    def _resolve_symbol(self, symbol_kw, n_args_expected):
+        if symbol_kw:
+            return symbol_kw
+        if self._last_symbol:
+            return self._last_symbol
+        raise TypeError("심볼 컨텍스트 미설정. filters.q_price('SYM', price)로 호출하거나, 먼저 filters.use('SYM')를 호출하세요.")
+
+    def q_price(self, *args, **kwargs) -> Decimal:
+        symbol_kw = kwargs.get("symbol")
+        if len(args) == 2 and isinstance(args[0], str):
+            symbol, price = args[0], args[1]
+        elif len(args) == 1:
+            symbol = self._resolve_symbol(symbol_kw, 1)
+            price = args[0]
+        else:
+            raise TypeError("q_price('SYM', price) 또는 q_price(price, symbol='SYM') 형태로 호출하세요.")
+        return self.map[symbol].q_price(self._coerce_decimal(price))
+
+    def q_qty(self, *args, **kwargs) -> Decimal:
+        symbol_kw = kwargs.get("symbol")
+        if len(args) == 2 and isinstance(args[0], str):
+            symbol, qty = args[0], args[1]
+        elif len(args) == 1:
+            symbol = self._resolve_symbol(symbol_kw, 1)
+            qty = args[0]
+        else:
+            raise TypeError("q_qty('SYM', qty) 또는 q_qty(qty, symbol='SYM') 형태로 호출하세요.")
+        return self.map[symbol].q_qty(self._coerce_decimal(qty))
+
+    def min_ok(self, *args, **kwargs) -> bool:
+        symbol_kw = kwargs.get("symbol")
+        if len(args) == 3 and isinstance(args[0], str):
+            symbol, price, qty = args
+        elif len(args) == 2:
+            symbol = self._resolve_symbol(symbol_kw, 2)
+            price, qty = args
+        else:
+            raise TypeError("min_ok('SYM', price, qty) 또는 min_ok(price, qty, symbol='SYM') 형태로 호출하세요.")
+        return self.map[symbol].min_ok(self._coerce_decimal(price), self._coerce_decimal(qty))
+
+    def tick_size(self, symbol: str) -> Decimal:
+        return self.map[symbol].tick
+
+    def step_size(self, symbol: str) -> Decimal:
+        return self.map[symbol].step
+
+    q_px = q_price
+    quantize_price = q_price
+    quantize_qty = q_qty

--- a/ftm2/trade/intent_queue.py
+++ b/ftm2/trade/intent_queue.py
@@ -74,6 +74,11 @@ class IntentQueue:
         while True:
             try:
                 for sym, it in list(self.intents.items()):
+                    filters = self.router.filters
+                    filters.use(sym)
+                    for need in ("q_price", "q_qty", "min_ok"):
+                        if not hasattr(filters, need):
+                            raise RuntimeError(f"ExchangeFilters has no {need}")
                     if not it.gates_ok:
                         continue
                     if it.autofire:

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -65,6 +65,10 @@ class OrderRouter:
         return True
 
     def place_entry(self, symbol: str, dec: SizingDecision, mark_price: float, trace: DecisionTrace | None = None):
+        self.filters.use(symbol)
+        for need in ("q_price", "q_qty", "min_ok"):
+            if not hasattr(self.filters, need):
+                raise RuntimeError(f"ExchangeFilters has no {need}")
         p, q = dec.sl, dec.qty
         entry_price = mark_price
         if not self._live_guard(symbol, q, entry_price, trace):
@@ -113,6 +117,10 @@ class OrderRouter:
             return None
 
     def place_brackets(self, symbol: str, side: str, qty: float, entry_price: float, sl: float, tp: float):
+        self.filters.use(symbol)
+        for need in ("q_price", "q_qty", "min_ok"):
+            if not hasattr(self.filters, need):
+                raise RuntimeError(f"ExchangeFilters has no {need}")
         reduce_side = "SELL" if side=="LONG" else "BUY"
         sl_price, sl_qty = quantize(self.filters, sl, qty)
         tp_price, tp_qty = quantize(self.filters, tp, qty)


### PR DESCRIPTION
## Summary
- add flexible wrappers and context tracking to ExchangeFilters
- set filter context before symbol loops and verify required methods
- handle listen key expiry and log chart rendering errors

## Testing
- `python -m py_compile analysis/engine.py exchange/quantize.py exchange/streams_user.py notify/discord_bot.py trade/intent_queue.py trade/order_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68affcb229b8832dbdcd2560473b5978