### PR TITLE
feat: refine notification dispatcher and gates

### DIFF
--- a/ftm2/config/settings.py
+++ b/ftm2/config/settings.py
@@ -21,6 +21,9 @@ class Settings(BaseModel):
     STARTUP_REQUIRE_NEW_BAR: bool = os.getenv("STARTUP_REQUIRE_NEW_BAR", "true").lower() == "true"
     SEND_SKIP_TO_TRADES: bool = os.getenv("SEND_SKIP_TO_TRADES", "false").lower() == "true"
     NOTIFY_THROTTLE_MS: int = int(os.getenv("NOTIFY_THROTTLE_MS", "60000"))
+    ENTRY_TF: str = os.getenv("ENTRY_TF", "1m")
+    ENTRY_COOLDOWN_SEC: int = int(os.getenv("ENTRY_COOLDOWN_SEC", "30"))
+    FILL_TIMEOUT_SEC: int = int(os.getenv("FILL_TIMEOUT_SEC", "2"))
     RENDER_CHARTS: bool = os.getenv("RENDER_CHARTS", "false").lower() == "true"
     RENDER_ON_NEW_BAR: bool = os.getenv("RENDER_ON_NEW_BAR", "true").lower() == "true"
     RENDER_INTERVAL_SEC: int = int(os.getenv("RENDER_INTERVAL_SEC", "180"))

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -1,25 +1,62 @@
+import os
 import time
-from ftm2.notify.discord_bot import send_trade as _send_trade, send_log as _send_log, send_signal as _send_signal
 
-# [ANCHOR:NOTIFY_THROTTLE]
-_throttle = {}
+from ftm2.config.settings import load_env_chain
+from ftm2.notify.discord_bot import (
+    send_trade as _send_trade,
+    send_log as _send_log,
+    send_signal as _send_signal,
+)
 
-def send_trade(text: str, embed=None):
-    _send_trade(text, embed)
 
-def send_log(text: str, embed=None):
-    _send_log(text, embed)
+class Notifier:
+    """Dispatch notifications to pre-configured channels."""
 
-def send_signal(text: str, embed=None):
-    _send_signal(text, embed)
+    def __init__(self, cfg=None):
+        self.cfg = cfg or load_env_chain()
+        self.ch_signals = os.getenv("CHANNEL_SIGNALS", "#포지션신호")
+        self.ch_trades = os.getenv("CHANNEL_TRADES", "#트레이딩")
+        self.ch_logs = os.getenv("CHANNEL_LOGS", "#로그")
+        self._throttle: dict[str, float] = {}
 
-def send_once(key: str, text: str, channel: str, ttl_ms: int, embed=None):
-    now = time.time() * 1000
-    last = _throttle.get(key, 0)
-    if now - last < ttl_ms:
-        return
-    _throttle[key] = now
-    if channel == "trades":
-        send_trade(text, embed)
-    else:
-        send_log(text, embed)
+    def _send(self, channel: str, text: str, embed=None):
+        if channel == self.ch_trades:
+            _send_trade(text, embed)
+        elif channel == self.ch_signals:
+            _send_signal(text, embed)
+        else:
+            _send_log(text, embed)
+
+    # 채널별 푸시 인터페이스 -------------------------------------------------
+    def push_signal(self, text: str, embed=None):
+        self._send(self.ch_signals, text, embed)
+
+    def push_trade(self, text: str, embed=None):
+        self._send(self.ch_trades, text, embed)
+
+    def push_log(self, text: str, embed=None):
+        self._send(self.ch_logs, text, embed)
+
+    # [ANCHOR:NOTIFY_THROTTLE]
+    def send_once(self, key: str, text: str, to: str = "logs", embed=None):
+        now = time.time() * 1000
+        last = self._throttle.get(key, 0)
+        if now - last < self.cfg.NOTIFY_THROTTLE_MS:
+            return
+        self._throttle[key] = now
+        if to == "signals":
+            self.push_signal(text, embed)
+        elif to == "trades":
+            self.push_trade(text, embed)
+        else:
+            self.push_log(text, embed)
+
+
+# 기본 인스턴스와 편의 함수 -------------------------------------------------
+notifier = Notifier()
+
+push_signal = notifier.push_signal
+push_trade = notifier.push_trade
+push_log = notifier.push_log
+send_once = notifier.send_once
+

--- a/ftm2/runtime/state.py
+++ b/ftm2/runtime/state.py
@@ -9,3 +9,5 @@ class RuntimeState:
         self.startup_until = self.boot_ts + self.cfg.STARTUP_HOLD_SEC
         self.autotrade_enabled = (self.cfg.AUTOTRADE_DEFAULT)
         self.analysis_ready = False  # 모든 TF 분석 1회 완료 후 True
+        self.idem_hit: dict[tuple[str, str], float] = {}
+        self.cooldown_until: dict[str, float] = {}

--- a/ftm2/trade/gates.py
+++ b/ftm2/trade/gates.py
@@ -1,9 +1,24 @@
 import time
 from typing import List, Tuple
 
-def pre_trade_gates(rt, cfg, market, sym: str, reasons: List[Tuple[str, str]] | None = None):
+
+def pre_trade_gates(rt, cfg, market, sym: str, dec, reasons: List[Tuple[str, str]] | None = None):
     """Check startup and autotrade gates."""
     reasons = reasons or []
+    # 동일 바/방향 중복 진입 금지
+    if hasattr(rt, "idem_hit") and hasattr(market, "bar_open_ts"):
+        key = (sym, dec.side)
+        bar_ts = market.bar_open_ts(sym, cfg.ENTRY_TF) if market else 0
+        last_hit = rt.idem_hit.get(key) if hasattr(rt, "idem_hit") else None
+        if last_hit == bar_ts:
+            reasons.append(("gate", "idem_same_bar"))
+            return False, reasons
+
+    # 체결 후 쿨다운
+    cool_until = rt.cooldown_until.get(sym, 0) if hasattr(rt, "cooldown_until") else 0
+    if time.time() < cool_until:
+        reasons.append(("gate", "cooldown"))
+        return False, reasons
     # [ANCHOR:GATE_STARTUP]
     now = time.time()
     if now < rt.startup_until:

--- a/ftm2/trade/intent_queue.py
+++ b/ftm2/trade/intent_queue.py
@@ -48,7 +48,7 @@ class IntentQueue:
 
         # notify intent
         try:
-            self.notify.send_log(f"{sym} 의도만: {direction} / {score:+.1f}")
+            self.notify.push_signal(f"{sym} 의도만: {direction} / {score:+.1f}")
         except Exception:
             pass
 
@@ -103,8 +103,7 @@ class IntentQueue:
                                 self.notify.send_once(
                                     f"intent_skip_{sym}",
                                     f"{sym} 의도 취소: 최소 명목 미달",
-                                    "logs",
-                                    self.cfg.NOTIFY_THROTTLE_MS,
+                                    to="signals",
                                 )
 
                             except Exception:
@@ -115,7 +114,7 @@ class IntentQueue:
                         ok = self.router.place_entry(sym, it.sizing, it.mark)
                         if ok:
                             try:
-                                self.notify.send_trade(
+                                self.notify.push_trade(
                                     f"{sym} 진입: {it.side} x{it.sizing.qty} @~{it.mark:.2f}"
                                 )
                             except Exception:
@@ -127,14 +126,15 @@ class IntentQueue:
                             if it.attempts >= self.cfg.INTENT_MAX_RETRY:
                                 self.intents.pop(sym, None)
                                 try:
-                                    self.notify.send_log(f"{sym} 의도 취소: 재시도 초과")
-
+                                    self.notify.push_signal(
+                                        f"{sym} 의도 취소: 재시도 초과"
+                                    )
                                 except Exception:
                                     pass
                 await asyncio.sleep(0.2)
             except Exception as e:
                 try:
-                    self.notify.send_log(f"[INTENT][ERR] {e}")
+                    self.notify.push_log(f"[INTENT][ERR] {e}")
                 except Exception:
                     pass
                 await asyncio.sleep(1.0)


### PR DESCRIPTION
## Summary
- add Notifier class with env-bound channels and throttled `send_once`
- update intent queue and order router to use new push-based notifications
- add entry cooldown gating and runtime state tracking

## Testing
- `python -m py_compile ftm2/notify/dispatcher.py ftm2/trade/intent_queue.py ftm2/trade/order_router.py ftm2/trade/gates.py ftm2/runtime/state.py ftm2/config/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68b04c7edc38832d8454e8d54f062dce