### PR TITLE
feat: add setup ticket pipeline

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+PIPELINE_MODE=tickets
+SCORING_TFS=1m,15m,1h,4h

--- a/ftm2/analysis/runner.py
+++ b/ftm2/analysis/runner.py
@@ -1,16 +1,54 @@
 import time
 
+
 class AnalysisRunner:
-    def __init__(self, rt):
+    def __init__(self, cfg, scoring, engine, notify, views, rt, symbols):
+        self.cfg = cfg
+        self.scoring = scoring
+        self.engine = engine
+        self.notify = notify
+        self.views = views
         self.rt = rt
+        self.symbols = symbols
+        self.prev_score: dict[str, int] = {}
+        self.prev_has_ticket: dict[str, bool] = {}
 
     def _all_tf_ready(self) -> bool:
         """Placeholder for timeframe readiness check."""
         return True
 
     def run_cycle(self):
-        """Run one analysis cycle."""
-        # ... analysis logic here ...
+        for sym in self.symbols:
+            score = self.scoring.mtf_score(sym)
+            ticket = self.engine.build_ticket(sym, score)
+
+            changed = (
+                abs(score - self.prev_score.get(sym, 0)) >= self.cfg.ANALYSIS_SCORE_DELTA_MIN
+            ) or (bool(ticket) != self.prev_has_ticket.get(sym, False))
+            if changed and getattr(self.notify, "edit_ok", lambda *a, **k: True)(
+                f"analysis_{sym}", self.cfg.ANALYSIS_EDIT_MIN_MS
+            ):
+                text = self.views.render(sym, score=score, ticket=ticket)
+                upsert = getattr(self.notify, "upsert_sticky", self.notify.emit)
+                upsert(
+                    self.cfg.CHANNEL_SIGNALS,
+                    f"analysis_{sym}",
+                    text,
+                    lifetime_min=self.cfg.ANALYSIS_LIFETIME_MIN,
+                )
+                if ticket:
+                    self.notify.emit(
+                        "intent",
+                        f"📡 SETUP: {sym} {ticket.side} score={ticket.score} RR≈{ticket.rr:.2f} SL={ticket.stop_px:.2f} TP1={ticket.tps[0]:.2f}",
+                    )
+
+            if ticket:
+                self.rt.active_ticket[sym] = ticket
+
+            self.prev_score[sym] = score
+            self.prev_has_ticket[sym] = bool(ticket)
+
         # [ANCHOR:ANALYSIS_READY_FLAG]
         if not self.rt.analysis_ready and self._all_tf_ready():
             self.rt.analysis_ready = True
+

--- a/ftm2/analysis/types.py
+++ b/ftm2/analysis/types.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import List
+
+
+# [SETUP_TICKET_DTO]
+@dataclass
+class SetupTicket:
+    id: str
+    symbol: str
+    side: str          # "LONG" | "SHORT"
+    tf: str
+    score: int         # -100..+100
+    entry_px: float
+    stop_px: float
+    tps: List[float]
+    rr: float
+    created_ts: float
+    expire_ts: float
+    reasons: List[str]
+

--- a/ftm2/config/settings.py
+++ b/ftm2/config/settings.py
@@ -8,6 +8,8 @@ class Settings(BaseModel):
     MODE: str = os.getenv("MODE", "testnet")  # legacy field
     TRADE_MODE: str = os.getenv("TRADE_MODE", MODE)  # testnet | live
     DATA_FEED: str = os.getenv("DATA_FEED", "live")  # live | testnet
+    # [PIPELINE_MODE]
+    PIPELINE_MODE: str = os.getenv("PIPELINE_MODE", "tickets")  # "tickets" | "legacy"
     WORKING_PRICE: str = os.getenv("WORKING_PRICE", "MARK_PRICE")
     LIVE_GUARD_ENABLE: bool = os.getenv("LIVE_GUARD_ENABLE", "true").lower() == "true"
     LIVE_MIN_NOTIONAL_USDT: float = float(os.getenv("LIVE_MIN_NOTIONAL_USDT", "10"))
@@ -26,8 +28,20 @@ class Settings(BaseModel):
     NOTIFY_STRICT: bool = os.getenv("NOTIFY_STRICT", "true").lower() == "true"
     NOTIFY_THROTTLE_MS: int = int(os.getenv("NOTIFY_THROTTLE_MS", "60000"))
     ENTRY_TF: str = os.getenv("ENTRY_TF", "1m")
-    ENTRY_COOLDOWN_SEC: int = int(os.getenv("ENTRY_COOLDOWN_SEC", "30"))
+    # [ANALYSIS/TICKET PARAMS]
+    SCORING_TFS: list[str] = os.getenv("SCORING_TFS", "1m,15m,1h,4h").split(",")
+    LONG_MIN_SCORE: int = int(os.getenv("LONG_MIN_SCORE", "60"))
+    SHORT_MIN_SCORE: int = int(os.getenv("SHORT_MIN_SCORE", "60"))
+    STOP_ATR: float = float(os.getenv("STOP_ATR", "1.5"))
+    TP1_ATR: float = float(os.getenv("TP1_ATR", "1.5"))
+    TP2_ATR: float = float(os.getenv("TP2_ATR", "3.0"))
+    MIN_RR: float = float(os.getenv("MIN_RR", "1.2"))
+    SETUP_TICKET_TTL_SEC: int = int(os.getenv("SETUP_TICKET_TTL_SEC", "300"))
     SETUP_INVALIDATION_BUFFER_PCT: float = float(os.getenv("SETUP_INVALIDATION_BUFFER_PCT", "0.05"))
+    ANALYSIS_SCORE_DELTA_MIN: int = int(os.getenv("ANALYSIS_SCORE_DELTA_MIN", "8"))
+    ANALYSIS_EDIT_MIN_MS: int = int(os.getenv("ANALYSIS_EDIT_MIN_MS", "15000"))
+    ANALYSIS_LIFETIME_MIN: int = int(os.getenv("ANALYSIS_LIFETIME_MIN", "55"))
+    ENTRY_COOLDOWN_SEC: int = int(os.getenv("ENTRY_COOLDOWN_SEC", "30"))
     FILL_TIMEOUT_SEC: int = int(os.getenv("FILL_TIMEOUT_SEC", "2"))
     RENDER_CHARTS: bool = os.getenv("RENDER_CHARTS", "false").lower() == "true"
     RENDER_ON_NEW_BAR: bool = os.getenv("RENDER_ON_NEW_BAR", "true").lower() == "true"

--- a/ftm2/runtime/state.py
+++ b/ftm2/runtime/state.py
@@ -13,4 +13,5 @@ class RuntimeState:
         self.cooldown_until: dict[str, float] = {}
         self.positions: dict[str, object] = {}
         self.last_position_update: float = 0.0
-        self.active_ticket: dict[str, object] = {}
+        # [RUNTIME_TICKETS]
+        self.active_ticket = {}     # {symbol: SetupTicket}

--- a/ftm2/strategy/scoring.py
+++ b/ftm2/strategy/scoring.py
@@ -1,0 +1,37 @@
+class Scoring:
+    def __init__(self, cfg, snap):
+        self.cfg = cfg
+        self.snap = snap
+
+    # [SCORE_STANDARDIZE_AND_MTF]
+    def mtf_score(self, sym: str):
+        # tf별 지표 스코어(0..1)와 ADX, 추세방향을 이미 갖고 있다고 가정
+        # 예: self.snap[tf].score01, self.snap[tf].adx, self.snap[tf].trend in {"UP","DOWN","FLAT"}
+        TFs = self.cfg.SCORING_TFS  # ["1m","15m","1h","4h"]
+        weights = {}
+        raw = {}
+        for tf in TFs:
+            s01 = self.snap[sym][tf].score01  # 0..1
+            adx = max(5.0, min(40.0, getattr(self.snap[sym][tf], "adx", 5.0) or 5.0))
+            w = adx / 40.0  # 0.125..1.0
+            raw[tf] = s01
+            weights[tf] = w
+
+        # HTF(1h/4h)와 LTF(1m/15m) 방향 일치 보정
+        htf_dir = self.snap[sym]["1h"].trend, self.snap[sym]["4h"].trend
+        ltf_dir = self.snap[sym]["1m"].trend, self.snap[sym]["15m"].trend
+        align_bonus = 0.0
+        if all(d == "UP" for d in htf_dir) and any(d == "UP" for d in ltf_dir):
+            align_bonus = +0.05
+        elif all(d == "DOWN" for d in htf_dir) and any(d == "DOWN" for d in ltf_dir):
+            align_bonus = -0.05
+
+        # 가중 평균
+        wsum = sum(weights.values()) or 1.0
+        score01 = sum(raw[tf] * weights[tf] for tf in TFs) / wsum
+        score01 = min(1.0, max(0.0, score01 + align_bonus))
+
+        # –100..+100 매핑 (0.5=중립)
+        score = int(round((score01 - 0.5) * 200))
+        return score
+

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -159,6 +159,9 @@ class OrderRouter:
                         route={"slippage":0, "post_only":self.cfg.POST_ONLY, "reduce_only":False, "type":params.get("type")})
             if self.bracket:
                 asyncio.create_task(self._place_bracket_async(symbol, dec.side, float(q_price), float(q_qty)))
+            # [CONSUME_TICKET]
+            if self.rt:
+                self.rt.active_ticket.pop(symbol, None)
             return od
         except Exception as e:
             print(f"[ORDER][ERR] {e}")


### PR DESCRIPTION
## Summary
- add pipeline mode toggle and ticket/scoring config
- introduce setup ticket dataclass and MTF scoring
- gate trades by setup tickets and consume on fill

## Testing
- `python -m py_compile ftm2/analysis/engine.py ftm2/analysis/runner.py ftm2/app.py ftm2/config/settings.py ftm2/runtime/state.py ftm2/trade/gates.py ftm2/trade/order_router.py ftm2/analysis/types.py ftm2/strategy/scoring.py`
- `pytest -q`
- `python - <<'PY'
from ftm2.runtime.state import RuntimeState
from ftm2.trade.gates import pre_trade_gates
class Cfg:
    ENTRY_TF='1m'
    STARTUP_REQUIRE_ANALYSIS=False
    STARTUP_REQUIRE_NEW_BAR=False
    SETUP_INVALIDATION_BUFFER_PCT=0.05
    STARTUP_HOLD_SEC=0
    AUTOTRADE_DEFAULT=True
rt = RuntimeState(Cfg())
class Market:
    def mark(self, sym): return 100
class Dec: side='LONG'
ok, reasons = pre_trade_gates(rt, Cfg(), Market(), 'BTCUSDT', Dec())
print('ok', ok, 'reasons', reasons)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b06037ca38832d92b1d3c3c4343b1c