### PR TITLE
Handle separate HTTP sessions in Binance client closure

### DIFF
--- a/ftm2/exchange/binance_client.py
+++ b/ftm2/exchange/binance_client.py
@@ -155,7 +155,10 @@ class BinanceClient:
 
     async def aclose(self):
         try:
-            sess = getattr(self, "session", None)
+            sess = getattr(self, "session_market", None)
+            if sess and not getattr(sess, "closed", True):
+                await sess.close()
+            sess = getattr(self, "session_trade", None)
             if sess and not getattr(sess, "closed", True):
                 await sess.close()
         except Exception:


### PR DESCRIPTION
## Summary
- close market and trade HTTP sessions separately in Binance client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0fee8e19c832d859d3a8a9c41eb4d