### PR TITLE
Persist upsert message IDs

### DIFF
--- a/ftm2/notify/discord_bot.py
+++ b/ftm2/notify/discord_bot.py
@@ -66,6 +66,8 @@ async def upsert(channel_key_or_name, text, *, dedupe_ms=3000, max_age_edit_s=33
     _last_emit_cache[k] = now
 
     mid_store = getattr(upsert, "_store", {})
+    if not hasattr(upsert, "_store"):
+        upsert._store = mid_store
     store = mid_store.setdefault(channel_key_or_name, {"id": None, "ts": 0})
     try:
         if store["id"] and (time.time() - store["ts"] < max_age_edit_s):


### PR DESCRIPTION
## Summary
- ensure discord_bot.upsert retains channel message IDs across calls by assigning internal store when missing

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b0fee7983c832d9a2e7bcf6e2e4e97