### PR TITLE
Await dispatch send function

### DIFF
--- a/ftm2/analysis/notify.py
+++ b/ftm2/analysis/notify.py
@@ -1,4 +1,13 @@
-# [ANCHOR:ANALYSIS_STICKY]
+import os
+from ftm2.notify.discord_bot import upsert
+
+# [ANALYSIS_STICKY_UPSERT]
+async def push_analysis(sym: str, txt: str, channel=None):
+    ch = channel or os.getenv("CHANNEL_ANALYSIS") or os.getenv("CHANNEL_SIGNALS") or "signals"
+    key = f"analysis::{sym}"
+    await upsert(ch, txt, sticky_key=key, dedupe_ms=2000, max_age_edit_s=3300)
+
+
 class AnalysisNotify:
     def __init__(self, cfg, views, notify):
         self.cfg = cfg

--- a/ftm2/notify/charts.py
+++ b/ftm2/notify/charts.py
@@ -1,9 +1,11 @@
 def _should_render(last_ts, now_ts, *, force_first: bool, cooldown_s: int, delta_ok: bool):
     if force_first and not last_ts:
-        return True
-    if cooldown_s > 0 and last_ts and (now_ts - last_ts) < cooldown_s * 1000:
-        return False
-    return bool(delta_ok)
+        return True, "first_render"
+    if cooldown_s>0 and last_ts and (now_ts - last_ts) < cooldown_s*1000:
+        return False, "cooldown"
+    if not delta_ok:
+        return False, "no_delta"
+    return True, "delta_pass"
 
 
 __all__ = ["_should_render"]

--- a/ftm2/notify/discord_bot.py
+++ b/ftm2/notify/discord_bot.py
@@ -54,36 +54,40 @@ def send_log(text: str, embed=None):    _send_queue.put_nowait(("logs", text, em
 def send_trade(text: str, embed=None):  _send_queue.put_nowait(("trades", text, embed))
 def send_signal(text: str, embed=None): _send_queue.put_nowait(("signals", text, embed))
 
-# [ANCHOR:UPSERT_MSG]
-_last_emit_cache = {}
+# [UPSERT_MSG]
+from ftm2.notify import dispatcher
 
+_last_payload_hash = {}
 
-async def upsert(channel_key_or_name, text, *, dedupe_ms=3000, max_age_edit_s=3300):
-    now = time.time() * 1000
-    k = (channel_key_or_name, text)
-    if now - _last_emit_cache.get(k, 0) < dedupe_ms:
-        return None
-    _last_emit_cache[k] = now
+def _payload_hash(txt: str) -> int:
+    return hash(txt.replace("\r\n", "\n").strip())
 
-    mid_store = getattr(upsert, "_store", {})
-    store = mid_store.setdefault(channel_key_or_name, {"id": None, "ts": 0})
+async def upsert(channel_key_or_name: str, text: str, *, dedupe_ms=3000, max_age_edit_s=3300, sticky_key=None):
+    now = time.time()*1000
+    ph = _payload_hash(text)
+    key = sticky_key or f"{channel_key_or_name}::default"
+
+    # 동일 페이로드는 dedupe_ms 내 생략
+    last = _last_payload_hash.get(key, (0, None, 0))
+    last_ts, last_mid, last_hash = last
+    if ph == last_hash and now - last_ts < dedupe_ms:
+        return last_mid
+
+    # 55분 이내면 edit, 아니면 새로 post
     try:
-        if store["id"] and (time.time() - store["ts"] < max_age_edit_s):
-            return await dispatcher.dc.edit(store["id"], text)
+        if last_mid and (time.time() - (last_ts/1000.0) < max_age_edit_s):
+            mid = await dispatcher.dc.edit(last_mid, text)
+            _last_payload_hash[key] = (now, last_mid, ph)
+            return mid
         else:
             mid = await dispatcher.dc.send(channel_key_or_name, text)
-            store["id"], store["ts"] = mid, time.time()
+            _last_payload_hash[key] = (now, mid, ph)
             return mid
-    except Exception as e:
-        try:
-            mid = await dispatcher.dc.send(channel_key_or_name, text)
-            store["id"], store["ts"] = mid, time.time()
-            return mid
-        except Exception:
-            await dispatcher.dc.send(
-                "logs", f"[UPSERT_FAIL->{channel_key_or_name}] {type(e).__name__}: {e}\n{text}"
-            )
-            return None
+    except Exception:
+        # 수정 실패(30046 등) -> 새로 보냄
+        mid = await dispatcher.dc.send(channel_key_or_name, text)
+        _last_payload_hash[key] = (now, mid, ph)
+        return mid
 
 
 async def send_signal_to_discord(sym: str, side: str, score: float, reasons: list[str], img_path: str | None = None):

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -1,86 +1,25 @@
 import os
 import time
+import asyncio
+import re
 from ftm2.config.settings import load_env_chain
 from ftm2.notify import discord_bot
 
-
-class Notifier:
-    # [ANCHOR:NOTIFIER_INIT]
-    def __init__(self, cfg, discord_client):
-        self.cfg = cfg
-        self.dc = discord_client
-        self._throttle: dict[str, float] = {}
-        # 채널 바인딩 (이름 또는 ID 지원)
-        self.ch_signals = cfg.CHANNEL_SIGNALS
-        self.ch_trades = cfg.CHANNEL_TRADES
-        self.ch_logs = cfg.CHANNEL_LOGS
-
-        # 이벤트 → 채널 맵(기본)
-        self.route = {
-            "intent": "signals",
-            "gate_skip": "signals",
-            "order_submitted": "signals",
-            "order_failed": "signals",
-            "fill": "trades",
-            "close": "trades",
-            "pnl": "trades",
-            "system": "logs",
-            "error": "logs",
-            "chart": "logs",
-        }
-
-    def _send(self, which: str, text: str):
-        ch = {
-            "signals": self.ch_signals,
-            "trades": self.ch_trades,
-            "logs": self.ch_logs,
-        }[which]
-        self.dc.send(ch, text)
-
-    def push_signal(self, text: str):
-        """Directly send to signal channel."""
-        self._send("signals", text)
-
-    def push_trade(self, text: str):
-        """Directly send to trade channel."""
-        self._send("trades", text)
-
-    def push_log(self, text: str):
-        """Directly send to log channel."""
-        self._send("logs", text)
-
-
-    def emit(self, event: str, text: str):
-        which = self.route.get(event, "logs")
-        if self.cfg.NOTIFY_STRICT:
-            if event in ("intent", "order_submitted", "order_failed", "gate_skip") and text.startswith("💹"):
-                text = text.replace("💹", "📡", 1)
-            if event in ("fill", "close", "pnl") and text.startswith("📡"):
-                text = text.replace("📡", "💹", 1)
-        self._send(which, text)
-
-    def emit_once(self, key: str, event: str, text: str, ttl_ms: int | None = None):
-        ttl = ttl_ms or self.cfg.NOTIFY_THROTTLE_MS
-        now = time.time() * 1000
-        last = self._throttle.get(key, 0)
-        if now - last < ttl:
-            return
-        self._throttle[key] = now
-        self.emit(event, text)
-
-
-    def send_once(self, key: str, text: str, to: str = "logs"):
-        now = time.time() * 1000
-        if now - self._throttle.get(key, 0) < self.cfg.NOTIFY_THROTTLE_MS:
-            return
-        self._throttle[key] = now
-        if to == "signals":
-            self.push_signal(text)
-        elif to == "trades":
-            self.push_trade(text)
-        else:
-            self.push_log(text)
-
+# [NOTIFY_MAP]
+# 조용한 시그널: 실제 액션만 signals로, 나머지는 logs로
+ROUTE_MAP = {
+    "intent": "logs",         # \ud83d\udcc9/\ud83d\udcc8 \uc810\uc218 \uc54c\ub9bc(\uc758\ub3c4\ub9cc) -> logs
+    "gate_skip": "logs",      # \uc9c4\uc785 \uae08\uc9c0 \uc0ac\uc720 -> logs
+    "intent_cancel": "logs",  # \uc7ac\uc2dc\ub3c4 \ucd08\uacfc/\ucde8\uc18c -> logs
+    "order_submitted": "signals",  # \uc2e4\uc81c \uc8fc\ubb38 \uc2dc\uae00\ub85c\ub9cc \uc2e0\ud638 \ucc44\ub110
+    "order_failed": "logs",
+    "fill": "trades",
+    "close": "trades",
+    "pnl": "trades",
+    "system": "logs",
+    "error": "logs",
+    "chart": "logs",          # \ucc28\ud2b8\ub294 VS \ub85c\uae45\uc쪾\ub85c\ub9cc
+}
 
 
 class _DiscordAdapter:
@@ -97,25 +36,17 @@ class _DiscordAdapter:
 
 
 _cfg = load_env_chain()
-notifier = Notifier(_cfg, _DiscordAdapter(_cfg))
-
-emit = notifier.emit
-emit_once = notifier.emit_once
-push_signal = notifier.push_signal
-push_trade = notifier.push_trade
-push_log = notifier.push_log
-send_once = notifier.send_once
+notifier = type("Notifier", (), {"dc": _DiscordAdapter(_cfg), "route": ROUTE_MAP})()
 
 async def send(channel_key_or_name: str, text: str):
     """Bridge to actual send implementation."""
-    notifier.dc.send(channel_key_or_name, text)
+    return await dc.send(channel_key_or_name, text)
 
 async def edit(message_id, text: str):
     return None
 
 
 # [ANCHOR:DISPATCHER_DC_ADAPTER_V2]
-import asyncio
 
 # 채널 별칭 → 실제 타겟(채널ID나 '#이름') 매핑
 # 실제 프로젝트에서 init 시점 또는 env에서 재설정됨을 가정
@@ -155,9 +86,11 @@ async def _send_impl(channel_key_or_name: str, text: str):
     실제 전송 함수에 연결. DRY 모드면 콘솔/로그만.
     """
     target = _resolve_channel(channel_key_or_name)
-    if 'send' in globals():
-        # 프로젝트의 실제 전송 함수명으로 맞추세요.
-        return await send(target, text)
+    if hasattr(notifier, "dc") and hasattr(notifier.dc, "send"):
+        result = notifier.dc.send(target, text)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
     # DRY/no-op fallback
     if 'emit' in globals():
         emit("system", f"[DRY][send->{target}] {text}")
@@ -170,7 +103,7 @@ async def _edit_impl(message_id, text: str):
         emit("system", f"[DRY][edit->{message_id}] {text}")
     return None
 
-=
+
 class _DCUseCtx:
     def __init__(self, parent, channel_key_or_name):
         self.parent = parent
@@ -193,6 +126,61 @@ class _DCAdapter:
 
 # 항상 dc를 노출(초기화 실패/DRY 상황에서도 None이 되지 않게)
 dc = _DCAdapter()
+
+
+# [EMIT_RATE_LIMIT]
+_LAST_EMIT: dict[str, int] = {}
+
+# \uc774\ubca4\ud2b8\ubcc4 \uae30\ubcf8 TTL(ms)
+EMIT_TTL = {
+    "gate_skip": 60_000,     # 1\ubd84\uc5d0 1\ubc88\ub9cc
+    "intent": 60_000,
+    "intent_cancel": 60_000,
+    "order_failed": 10_000,
+    "system": 5_000,
+    "error": 5_000,
+    "chart": 30_000,        # \ucc28\ud2b8\ub3c4 \uc7a5\ucc28\uac00 \uc548 \uc62c\ub9bc
+}
+
+def _normalize(kind: str, text: str) -> str:
+    """\ub3d9\uc77c \uba54\uc2dc\uc9c0\ub85c \ucde8\uae09\ud558\uae30 \uc704\ud55c \uc815\uaddc\ud654"""
+    t = re.sub(r"\s+", " ", str(text)).strip()
+    t = re.sub(r"@~\d+(\.\d+)?", "@~PX", t)
+    t = re.sub(r"\d+(\.\d+)?", "N", t)
+    return f"{kind}:{t}"
+
+async def _emit(kind: str, text: str, route: str | None = None, *, ttl_ms: int | None = None):
+    route = route or ROUTE_MAP.get(kind, "logs")
+    ttl = EMIT_TTL.get(kind, 0) if ttl_ms is None else max(0, int(ttl_ms))
+    key = _normalize(kind, text)
+    now = int(time.time() * 1000)
+    last = _LAST_EMIT.get(key, 0)
+    if ttl and now - last < ttl:
+        return None
+    _LAST_EMIT[key] = now
+
+    from ftm2.notify import dispatcher as dp  # self import safe
+    try:
+        return await dp.dc.send(route, text)
+    except Exception as e:
+        try:
+            return await dp.dc.send("logs", f"[EMIT_FAIL->{route}] {type(e).__name__}: {e}\n{text}")
+        except Exception:
+            return None
+
+def emit(kind: str, text: str, route: str | None = None, *, ttl_ms: int | None = None):
+    return asyncio.create_task(_emit(kind, text, route, ttl_ms=ttl_ms))
+
+_THROTTLE: dict[str, int] = {}
+
+def emit_once(key: str, kind: str, text: str, ttl_ms: int | None = None):
+    ttl = ttl_ms or 0
+    now = int(time.time() * 1000)
+    last = _THROTTLE.get(key, 0)
+    if ttl and now - last < ttl:
+        return None
+    _THROTTLE[key] = now
+    return emit(kind, text)
 
 
 def configure_channels(**kw):

--- a/ftm2/trade/intent_queue.py
+++ b/ftm2/trade/intent_queue.py
@@ -120,8 +120,8 @@ class IntentQueue:
                             if it.attempts >= self.cfg.INTENT_MAX_RETRY:
                                 self.intents.pop(sym, None)
                                 try:
-                                    self.notify.emit(
-                                        "gate_skip", f"📡 {sym} 의도 취소: 재시도 초과"
+                                    await self.notify.emit(
+                                        "intent_cancel", f"📡 {sym} 의도 취소: 재시도 초과", ttl_ms=120_000
                                     )
                                 except Exception:
                                     pass

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -56,7 +56,9 @@ class OrderRouter:
         # 0) 티켓 게이트
         tk = self.rt.active_ticket.get(sym)
         if not tk:
-            self.notify.emit("gate_skip", f"📡 {sym} 티켓없음 → 진입 금지")
+            await self.notify.emit(
+                "gate_skip", f"📡 {sym} 티켓없음 → 진입 금지", ttl_ms=120_000
+            )
             return False
 
         # 1) 사이징


### PR DESCRIPTION
## Summary
- quiet dispatcher routing and add rate-limited emit with channel map
- add sticky upsert helper for Discord and use it for ops board and analysis updates
- ensure charts render at least once and trim noisy intent notifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fee59be0832da60b207f4740d317