### PR TITLE
Await dispatch send function

### DIFF
--- a/ftm2/analysis/notify.py
+++ b/ftm2/analysis/notify.py
@@ -1,4 +1,13 @@
-# [ANCHOR:ANALYSIS_STICKY]
+import os
+from ftm2.notify.discord_bot import upsert
+
+# [ANALYSIS_STICKY_UPSERT]
+async def push_analysis(sym: str, txt: str, channel=None):
+    ch = channel or os.getenv("CHANNEL_ANALYSIS") or os.getenv("CHANNEL_SIGNALS") or "signals"
+    key = f"analysis::{sym}"
+    await upsert(ch, txt, sticky_key=key, dedupe_ms=2000, max_age_edit_s=3300)
+
+
 class AnalysisNotify:
     def __init__(self, cfg, views, notify):
         self.cfg = cfg

--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -56,13 +56,6 @@ from ftm2 import strategy as ST
 
 
 CFG = load_env_chain()
-# [ANCHOR:DISPATCHER_BOOTSTRAP]
-notify.ensure_dc()
-notify.configure_channels(
-    signals=os.getenv("CHANNEL_SIGNALS"),
-    trades=os.getenv("CHANNEL_TRADES"),
-    logs=os.getenv("CHANNEL_LOGS"),
-)
 
 object.__setattr__(CFG, "ANALYSIS_READY", asyncio.Event())
 
@@ -221,6 +214,14 @@ async def main():
     info = bx.load_exchange_info()
     print(f"[FTM2] exchangeInfo symbols={len(info.get('symbols', []))} FILTERS OK")
 
+    from ftm2.notify import dispatcher as notify_dp
+    notify_dp.configure_channels(
+        signals=os.getenv("CHANNEL_SIGNALS"),
+        trades=os.getenv("CHANNEL_TRADES"),
+        logs=os.getenv("CHANNEL_LOGS"),
+    )
+    await notify_dp.flush_boot_queue()
+
     # 라우터/가드/트래커 초기화
     global ROUTER, GUARD, BX, CSV, LEDGER, div, INTQ
     brkt = Bracket(CFG, bx, bx.filters)
@@ -263,7 +264,7 @@ async def main():
 
     INTQ = IntentQueue(CFG, div, ROUTER, CSV, notify)
     ops_board = OpsBoard(CFG, notify, dash_collect, render_ops_board)
-    notify.emit("system", f"[NOTIFY_MAP] {notify.notifier.route}")
+    notify.emit("system", f"[NOTIFY_MAP] {notify.ROUTE_MAP}")
     notify.emit("intent", "📡 [테스트] 신호 채널 확인")
     notify.emit("fill", "💹 [테스트] 트레이드 채널 확인")
 

--- a/ftm2/notify/charts.py
+++ b/ftm2/notify/charts.py
@@ -1,9 +1,11 @@
 def _should_render(last_ts, now_ts, *, force_first: bool, cooldown_s: int, delta_ok: bool):
     if force_first and not last_ts:
-        return True
-    if cooldown_s > 0 and last_ts and (now_ts - last_ts) < cooldown_s * 1000:
-        return False
-    return bool(delta_ok)
+        return True, "first_render"
+    if cooldown_s>0 and last_ts and (now_ts - last_ts) < cooldown_s*1000:
+        return False, "cooldown"
+    if not delta_ok:
+        return False, "no_delta"
+    return True, "delta_pass"
 
 
 __all__ = ["_should_render"]

--- a/ftm2/notify/discord_bot.py
+++ b/ftm2/notify/discord_bot.py
@@ -54,36 +54,40 @@ def send_log(text: str, embed=None):    _send_queue.put_nowait(("logs", text, em
 def send_trade(text: str, embed=None):  _send_queue.put_nowait(("trades", text, embed))
 def send_signal(text: str, embed=None): _send_queue.put_nowait(("signals", text, embed))
 
-# [ANCHOR:UPSERT_MSG]
-_last_emit_cache = {}
+# [UPSERT_MSG]
+from ftm2.notify import dispatcher
 
+_last_payload_hash = {}
 
-async def upsert(channel_key_or_name, text, *, dedupe_ms=3000, max_age_edit_s=3300):
-    now = time.time() * 1000
-    k = (channel_key_or_name, text)
-    if now - _last_emit_cache.get(k, 0) < dedupe_ms:
-        return None
-    _last_emit_cache[k] = now
+def _payload_hash(txt: str) -> int:
+    return hash(txt.replace("\r\n", "\n").strip())
 
-    mid_store = getattr(upsert, "_store", {})
-    store = mid_store.setdefault(channel_key_or_name, {"id": None, "ts": 0})
+async def upsert(channel_key_or_name: str, text: str, *, dedupe_ms=3000, max_age_edit_s=3300, sticky_key=None):
+    now = time.time()*1000
+    ph = _payload_hash(text)
+    key = sticky_key or f"{channel_key_or_name}::default"
+
+    # 동일 페이로드는 dedupe_ms 내 생략
+    last = _last_payload_hash.get(key, (0, None, 0))
+    last_ts, last_mid, last_hash = last
+    if ph == last_hash and now - last_ts < dedupe_ms:
+        return last_mid
+
+    # 55분 이내면 edit, 아니면 새로 post
     try:
-        if store["id"] and (time.time() - store["ts"] < max_age_edit_s):
-            return await dispatcher.dc.edit(store["id"], text)
+        if last_mid and (time.time() - (last_ts/1000.0) < max_age_edit_s):
+            mid = await dispatcher.dc.edit(last_mid, text)
+            _last_payload_hash[key] = (now, last_mid, ph)
+            return mid
         else:
             mid = await dispatcher.dc.send(channel_key_or_name, text)
-            store["id"], store["ts"] = mid, time.time()
+            _last_payload_hash[key] = (now, mid, ph)
             return mid
-    except Exception as e:
-        try:
-            mid = await dispatcher.dc.send(channel_key_or_name, text)
-            store["id"], store["ts"] = mid, time.time()
-            return mid
-        except Exception:
-            await dispatcher.dc.send(
-                "logs", f"[UPSERT_FAIL->{channel_key_or_name}] {type(e).__name__}: {e}\n{text}"
-            )
-            return None
+    except Exception:
+        # 수정 실패(30046 등) -> 새로 보냄
+        mid = await dispatcher.dc.send(channel_key_or_name, text)
+        _last_payload_hash[key] = (now, mid, ph)
+        return mid
 
 
 async def send_signal_to_discord(sym: str, side: str, score: float, reasons: list[str], img_path: str | None = None):

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -1,212 +1,159 @@
-import os
-import time
-from ftm2.config.settings import load_env_chain
+import os, re, time, asyncio
 from ftm2.notify import discord_bot
 
+# 별칭 → 실제 대상(채널ID, '#이름', 별칭 그대로)
+CHANNELS = {
+    "signals": os.getenv("CHANNEL_SIGNALS", "signals"),
+    "trades": os.getenv("CHANNEL_TRADES", "trades"),
+    "logs": os.getenv("CHANNEL_LOGS", "logs"),
+}
 
-class Notifier:
-    # [ANCHOR:NOTIFIER_INIT]
-    def __init__(self, cfg, discord_client):
-        self.cfg = cfg
-        self.dc = discord_client
-        self._throttle: dict[str, float] = {}
-        # 채널 바인딩 (이름 또는 ID 지원)
-        self.ch_signals = cfg.CHANNEL_SIGNALS
-        self.ch_trades = cfg.CHANNEL_TRADES
-        self.ch_logs = cfg.CHANNEL_LOGS
+def configure_channels(**kw):
+    """런타임에서 채널 매핑 갱신 (부팅 중에도 호출 안전)"""
+    for k, v in kw.items():
+        if v:
+            CHANNELS[k] = v
+    # 부팅 시점엔 루프가 없을 수 있으므로 emit은 그냥 큐에 쌓임
+    emit("system", f"[NOTIFY_CHANNELS] {CHANNELS}")
 
-        # 이벤트 → 채널 맵(기본)
-        self.route = {
-            "intent": "signals",
-            "gate_skip": "signals",
-            "order_submitted": "signals",
-            "order_failed": "signals",
-            "fill": "trades",
-            "close": "trades",
-            "pnl": "trades",
-            "system": "logs",
-            "error": "logs",
-            "chart": "logs",
-        }
+def _resolve_channel(key_or_name: str):
+    if not key_or_name:
+        return CHANNELS.get("signals", "signals")
+    k = str(key_or_name).strip()
+    if k in CHANNELS:
+        return CHANNELS[k]
+    if k.startswith("#") or k.isdigit():
+        return k
+    for _, v in CHANNELS.items():
+        if v == k:
+            return v
+    return CHANNELS.get("signals", "signals")
 
-    def _send(self, which: str, text: str):
-        ch = {
-            "signals": self.ch_signals,
-            "trades": self.ch_trades,
-            "logs": self.ch_logs,
-        }[which]
-        self.dc.send(ch, text)
+# ---------- 라우팅 맵(시그널 조용하게) ----------
+ROUTE_MAP = {
+    "intent": "logs",  # 의도만 → logs
+    "gate_skip": "logs",  # 진입 금지 → logs
+    "intent_cancel": "logs",  # 의도 취소/재시도 초과 → logs
+    "order_submitted": "signals",  # 실제 주문만 시그널
+    "order_failed": "logs",
+    "fill": "trades",
+    "close": "trades",
+    "pnl": "trades",
+    "system": "logs",
+    "error": "logs",
+    "chart": "logs",
+}
 
-    def push_signal(self, text: str):
-        """Directly send to signal channel."""
-        self._send("signals", text)
+# ---------- 스팸 억제 ----------
+_LAST_EMIT: dict[str, int] = {}
+EMIT_TTL = {
+    "gate_skip": 60_000,
+    "intent": 60_000,
+    "intent_cancel": 60_000,
+    "order_failed": 10_000,
+    "system": 5_000,
+    "error": 5_000,
+    "chart": 30_000,
+}
 
-    def push_trade(self, text: str):
-        """Directly send to trade channel."""
-        self._send("trades", text)
+def _norm(kind: str, text: str) -> str:
+    t = re.sub(r"\s+", " ", str(text)).strip()
+    t = re.sub(r"@~\d+(\.\d+)?", "@~PX", t)
+    t = re.sub(r"\d+(\.\d+)?", "N", t)
+    return f"{kind}:{t}"
 
-    def push_log(self, text: str):
-        """Directly send to log channel."""
-        self._send("logs", text)
-
-
-    def emit(self, event: str, text: str):
-        which = self.route.get(event, "logs")
-        if self.cfg.NOTIFY_STRICT:
-            if event in ("intent", "order_submitted", "order_failed", "gate_skip") and text.startswith("💹"):
-                text = text.replace("💹", "📡", 1)
-            if event in ("fill", "close", "pnl") and text.startswith("📡"):
-                text = text.replace("📡", "💹", 1)
-        self._send(which, text)
-
-    def emit_once(self, key: str, event: str, text: str, ttl_ms: int | None = None):
-        ttl = ttl_ms or self.cfg.NOTIFY_THROTTLE_MS
-        now = time.time() * 1000
-        last = self._throttle.get(key, 0)
-        if now - last < ttl:
-            return
-        self._throttle[key] = now
-        self.emit(event, text)
-
-
-    def send_once(self, key: str, text: str, to: str = "logs"):
-        now = time.time() * 1000
-        if now - self._throttle.get(key, 0) < self.cfg.NOTIFY_THROTTLE_MS:
-            return
-        self._throttle[key] = now
-        if to == "signals":
-            self.push_signal(text)
-        elif to == "trades":
-            self.push_trade(text)
-        else:
-            self.push_log(text)
-
-
-
-class _DiscordAdapter:
-    def __init__(self, cfg):
-        self.cfg = cfg
-
-    def send(self, channel: str, text: str):
-        if channel == self.cfg.CHANNEL_TRADES:
-            discord_bot.send_trade(text)
-        elif channel == self.cfg.CHANNEL_SIGNALS:
-            discord_bot.send_signal(text)
-        else:
-            discord_bot.send_log(text)
-
-
-_cfg = load_env_chain()
-notifier = Notifier(_cfg, _DiscordAdapter(_cfg))
-
-emit = notifier.emit
-emit_once = notifier.emit_once
-push_signal = notifier.push_signal
-push_trade = notifier.push_trade
-push_log = notifier.push_log
-send_once = notifier.send_once
+# ---------- 부팅 큐 ----------
+_BOOT_QUEUE: list[tuple[str, str, str | None, int | None]] = []
 
 async def send(channel_key_or_name: str, text: str):
-    """Bridge to actual send implementation."""
-    notifier.dc.send(channel_key_or_name, text)
+    alias = None
+    for k, v in CHANNELS.items():
+        if v == channel_key_or_name or k == channel_key_or_name:
+            alias = k
+            break
+    if alias == "trades":
+        discord_bot.send_trade(text)
+    elif alias == "signals":
+        discord_bot.send_signal(text)
+    else:
+        discord_bot.send_log(text)
+    return None
 
 async def edit(message_id, text: str):
     return None
 
-
-# [ANCHOR:DISPATCHER_DC_ADAPTER_V2]
-import asyncio
-
-# 채널 별칭 → 실제 타겟(채널ID나 '#이름') 매핑
-# 실제 프로젝트에서 init 시점 또는 env에서 재설정됨을 가정
-CHANNELS = {
-    "signals": os.getenv("CHANNEL_SIGNALS", "signals"),
-    "trades":  os.getenv("CHANNEL_TRADES", "trades"),
-    "logs":    os.getenv("CHANNEL_LOGS", "logs"),
-}
-
-def _resolve_channel(key_or_name: str):
-    """
-    'signals' 같은 별칭, '#포지션신호' 같은 디스코드 채널명, '1234567890' 같은 ID 모두 허용.
-    매칭 실패 시 'signals'로 폴백.
-    """
-    if not key_or_name:
-        return CHANNELS.get("signals", "signals")
-
-    k = str(key_or_name).strip()
-    # 1) 별칭이면 매핑
-    if k in CHANNELS:
-        return CHANNELS[k]
-    # 2) '#이름' 그대로 허용
-    if k.startswith("#"):
-        return k
-    # 3) 숫자(ID)면 그대로 반환
-    if k.isdigit():
-        return k
-    # 4) 값으로 '#이름' 저장된 경우 역탐색
-    for alias, val in CHANNELS.items():
-        if val == k:
-            return val
-    # 5) 폴백
-    return CHANNELS.get("signals", "signals")
-
-async def _send_impl(channel_key_or_name: str, text: str):
-    """
-    실제 전송 함수에 연결. DRY 모드면 콘솔/로그만.
-    """
-    target = _resolve_channel(channel_key_or_name)
+async def _send_impl(target_key_or_name: str, text: str):
+    target = _resolve_channel(target_key_or_name)
     if 'send' in globals():
-        # 프로젝트의 실제 전송 함수명으로 맞추세요.
         return await send(target, text)
-    # DRY/no-op fallback
-    if 'emit' in globals():
-        emit("system", f"[DRY][send->{target}] {text}")
+    if 'emit' in globals():  # DRY/no-op
+        try:
+            emit("system", f"[DRY][send->{target}] {text}", route="logs")
+        except Exception:
+            pass
     return None
 
 async def _edit_impl(message_id, text: str):
     if 'edit' in globals():
         return await edit(message_id, text)
     if 'emit' in globals():
-        emit("system", f"[DRY][edit->{message_id}] {text}")
+        try:
+            emit("system", f"[DRY][edit->{message_id}] {text}", route="logs")
+        except Exception:
+            pass
     return None
 
-=
+async def _emit(kind: str, text: str, route: str | None, *, ttl_ms: int | None):
+    route = route or ROUTE_MAP.get(kind, "logs")
+    ttl = EMIT_TTL.get(kind, 0) if ttl_ms is None else max(0, int(ttl_ms))
+    key = _norm(kind, text)
+    now = int(time.time() * 1000)
+    last = _LAST_EMIT.get(key, 0)
+    if ttl and now - last < ttl:
+        return None
+    _LAST_EMIT[key] = now
+    return await _send_impl(route, text)
+
+def emit(kind: str, text: str, route: str | None = None, *, ttl_ms: int | None = None):
+    """
+    부팅 전(루프 없음)에도 안전. 루프가 없으면 부팅 큐에 저장,
+    루프가 있으면 현재 루프에 task로 올림.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        return loop.create_task(_emit(kind, text, route, ttl_ms=ttl_ms))
+    except RuntimeError:
+        _BOOT_QUEUE.append((kind, text, route, ttl_ms))
+        return None
+
+async def flush_boot_queue():
+    """루프가 돌기 시작하면 한 번 호출해서 부팅 큐를 비워 전송"""
+    while _BOOT_QUEUE:
+        kind, text, route, ttl = _BOOT_QUEUE.pop(0)
+        try:
+            await _emit(kind, text, route, ttl_ms=ttl)
+        except Exception:
+            pass
+
+# ---------- dc 어댑터(항상 객체 보장) ----------
 class _DCUseCtx:
-    def __init__(self, parent, channel_key_or_name):
-        self.parent = parent
-        self.target = channel_key_or_name
-    async def send(self, text: str):
+    def __init__(self, target):
+        self.target = target
+
+    async def send(self, text):
         return await _send_impl(self.target, text)
-    async def edit(self, message_id, text: str):
-        return await _edit_impl(message_id, text)
+
+    async def edit(self, mid, text):
+        return await _edit_impl(mid, text)
 
 class _DCAdapter:
-    async def send(self, channel_key_or_name: str, text: str):
-        return await _send_impl(channel_key_or_name, text)
+    def use(self, target: str):
+        return _DCUseCtx(target)
+
+    async def send(self, target: str, text: str):
+        return await _send_impl(target, text)
+
     async def edit(self, message_id, text: str):
         return await _edit_impl(message_id, text)
-    def use(self, channel_key_or_name: str):
-        """
-        notify.dc.use('signals').send('...') 형태 지원
-        """
-        return _DCUseCtx(self, channel_key_or_name)
 
-# 항상 dc를 노출(초기화 실패/DRY 상황에서도 None이 되지 않게)
 dc = _DCAdapter()
-
-
-def configure_channels(**kw):
-    """
-    런타임에서 CHANNELS 갱신(예: env 반영).
-    """
-    CHANNELS.update({k: v for k, v in kw.items() if v})
-    if 'emit' in globals():
-        emit("system", f"[NOTIFY_CHANNELS] {CHANNELS}")
-
-def ensure_dc():
-    """외부에서 보증 호출 가능(이미 객체면 그대로 둠)"""
-    global dc
-    if dc is None or not hasattr(dc, "send") or not hasattr(dc, "use"):
-        dc = _DCAdapter()
-    return dc
-

--- a/ftm2/trade/intent_queue.py
+++ b/ftm2/trade/intent_queue.py
@@ -120,8 +120,8 @@ class IntentQueue:
                             if it.attempts >= self.cfg.INTENT_MAX_RETRY:
                                 self.intents.pop(sym, None)
                                 try:
-                                    self.notify.emit(
-                                        "gate_skip", f"📡 {sym} 의도 취소: 재시도 초과"
+                                    await self.notify.emit(
+                                        "intent_cancel", f"📡 {sym} 의도 취소: 재시도 초과", ttl_ms=120_000
                                     )
                                 except Exception:
                                     pass

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -56,7 +56,9 @@ class OrderRouter:
         # 0) 티켓 게이트
         tk = self.rt.active_ticket.get(sym)
         if not tk:
-            self.notify.emit("gate_skip", f"📡 {sym} 티켓없음 → 진입 금지")
+            await self.notify.emit(
+                "gate_skip", f"📡 {sym} 티켓없음 → 진입 금지", ttl_ms=120_000
+            )
             return False
 
         # 1) 사이징


### PR DESCRIPTION
## Summary
- quiet dispatcher routing and add rate-limited emit with channel map
- add sticky upsert helper for Discord and use it for ops board and analysis updates
- ensure charts render at least once and trim noisy intent notifications
- make dispatcher boot-safe and flush queued emits after startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fee59be0832da60b207f4740d317