### PR TITLE
Persist upsert message IDs

### DIFF
--- a/ftm2/config/settings.py
+++ b/ftm2/config/settings.py
@@ -14,6 +14,13 @@ class Settings(BaseModel):
     LIVE_GUARD_ENABLE: bool = os.getenv("LIVE_GUARD_ENABLE", "true").lower() == "true"
     LIVE_MIN_NOTIONAL_USDT: float = float(os.getenv("LIVE_MIN_NOTIONAL_USDT", "10"))
     ORDER_SCALE_TO_MIN: bool = os.getenv("ORDER_SCALE_TO_MIN", "true").lower() == "true"
+    ORDER_RECV_WINDOW_MS: int = int(os.getenv("ORDER_RECV_WINDOW_MS", os.getenv("RECV_WINDOW_MS", "5000")))
+    ORDER_AUTOSCALE_TO_MIN: bool = os.getenv(
+        "ORDER_AUTOSCALE_TO_MIN",
+        os.getenv("ORDER_SCALE_TO_MIN", "true"),
+    ).lower() == "true"
+    ORDER_RETRIES: int = int(os.getenv("ORDER_RETRIES", "3"))
+    ORDER_BACKOFF_MS: int = int(os.getenv("ORDER_BACKOFF_MS", "500"))
     INTENT_AUTOFIRE_SCALE_TO_MIN: bool = os.getenv("INTENT_AUTOFIRE_SCALE_TO_MIN", "true").lower() == "true"
     INTENT_BACKOFF_MS: int = int(os.getenv("INTENT_BACKOFF_MS", "1500"))
     INTENT_MAX_RETRY: int = int(os.getenv("INTENT_MAX_RETRY", "5"))

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -17,8 +17,9 @@ class Notifier:
 
         # 이벤트 → 채널 맵(기본)
         self.route = {
-            "intent": "signals",
-            "gate_skip": "signals",
+            "intent": "logs",
+            "gate_skip": "logs",
+            "intent_cancel": "logs",
             "order_submitted": "signals",
             "order_failed": "signals",
             "fill": "trades",

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -1,5 +1,6 @@
 import time
 from ftm2.notify import dispatcher
+from ftm2.notify.discord_bot import upsert
 from ftm2.journal.events import JEvent
 from ftm2.trade.order_fsm import OFSM, OState
 from ftm2.trade.cid import build_cid
@@ -93,7 +94,7 @@ class OrderRouter:
                 quantity=str(qty),
                 newClientOrderId=cid,
                 timestamp=tg.now_ms(),
-                recvWindow=self.cfg.ORDER_RECV_WINDOW_MS,
+                recvWindow=self.cfg.RECV_WINDOW_MS,
             )
 
         try:
@@ -173,11 +174,12 @@ class OrderRouter:
                 stop=sl,
                 tps=[px for px, _ in tps],
             )
-            self.notify._upsert_sticky(
+            await upsert(
                 self.cfg.CHANNEL_SIGNALS,
-                f"analysis_{sym}",
                 text,
-                lifetime_min=self.cfg.ANALYSIS_LIFETIME_MIN,
+                sticky_key=f"analysis::{sym}",
+                dedupe_ms=2000,
+                max_age_edit_s=3300,
             )
 
         # 8) 알림

--- a/ftm2/web/app.py
+++ b/ftm2/web/app.py
@@ -1,5 +1,9 @@
 # [ANCHOR:WEB_APP]
-import os, asyncio, uvicorn
+import os, asyncio
+try:
+    import uvicorn
+except ImportError:
+    uvicorn = None  # WEB_ENABLE true일 때만 필요
 from fastapi import FastAPI, Depends, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -85,6 +89,12 @@ def init(app, cfg, rt, market, bracket, notify):
 
     return broadcaster
 
+def run(host="0.0.0.0", port=8088):
+    if uvicorn is None:
+        raise RuntimeError("uvicorn not installed; set WEB_ENABLE=false or pip install uvicorn")
+    uvicorn.run(app, host=host, port=port, log_level="info")
+
+
 def run_standalone(cfg, rt, market, bracket, notify):
     init(app, cfg, rt, market, bracket, notify)
-    uvicorn.run(app, host=os.getenv("WEB_HOST","0.0.0.0"), port=int(os.getenv("WEB_PORT","8088")))
+    run(host=os.getenv("WEB_HOST", "0.0.0.0"), port=int(os.getenv("WEB_PORT", "8088")))


### PR DESCRIPTION
## Summary
- ensure discord_bot.upsert retains channel message IDs across calls by assigning internal store when missing
- replace invalid OrderRouter sticky call with discord_bot.upsert and unify recvWindow config
- define default ORDER_* settings and lazy-load uvicorn
- send intent-related notifications to logs instead of signals

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68b0fee7983c832d9a2e7bcf6e2e4e97