### PR TITLE
fix: stabilize notification dispatcher and Discord adapter

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -207,20 +207,14 @@ async def on_market(msg):
 
 
 async def main():
+    notify.configure_channels({
+        "signals": CFG.CHANNEL_SIGNALS,
+        "trades": CFG.CHANNEL_TRADES,
+        "logs": CFG.CHANNEL_LOGS,
+    })
     await notify.flush_boot_queue()
     print(f"[FTM2][BOOT_ENV_SUMMARY] MODE={CFG.MODE}, SYMBOLS={CFG.SYMBOLS}, INTERVAL={CFG.INTERVAL}")
     print(f"[FTM2] APIKEY={(CFG.BINANCE_API_KEY[:4] + '…') if CFG.BINANCE_API_KEY else 'EMPTY'}")
-    notify.configure_channels({
-        "signals": "signals",
-        "trades": "trades",
-        "logs": "logs",
-    })
-    fbq = getattr(notify, "flush_boot_queue", None)
-    if fbq:
-        if inspect.iscoroutinefunction(fbq):
-            await fbq()
-        else:
-            fbq()
 
     bx = BinanceClient()
     t = bx.server_time()

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -10,7 +10,7 @@ try:
 except Exception as e:
     _bot = None
 
-async def _missing_async(*args, **kwargs):
+async def _missing(*args, **kwargs):
     raise RuntimeError("discord_bot API(send/edit/upsert)가 구현되어 있지 않습니다.")
 
 def _noop_use(*args, **kwargs):
@@ -18,9 +18,9 @@ def _noop_use(*args, **kwargs):
     return None
 
 dc = SimpleNamespace(
-    send=(getattr(_bot, "send", None) or _missing_async),
-    edit=(getattr(_bot, "edit", None) or _missing_async),
-    upsert=(getattr(_bot, "upsert", None) or _missing_async),
+    send=(getattr(_bot, "send", None) or _missing),
+    edit=(getattr(_bot, "edit", None) or _missing),
+    upsert=(getattr(_bot, "upsert", None) or _missing),
     use=(getattr(_bot, "use", None) or _noop_use),
 )
 
@@ -38,8 +38,8 @@ def _resolve_channel(key_or_name):
     if isinstance(k, str):
         if k in _CHANNELS:
             return _CHANNELS[k]
-        if k.startswith("#") and k in _CHANNELS:
-            return _CHANNELS[k]
+        if k.startswith("#") and k[1:] in _CHANNELS:
+            return _CHANNELS[k[1:]]
         if k.isdigit():
             return int(k)
     return k  # 마지막 방어
@@ -125,6 +125,9 @@ async def _send_impl(target, text: str):
 async def send(channel_key_or_name, text: str):
     return await _send_impl(channel_key_or_name, text)
 
+async def edit(message_id, text: str):
+    return await dc.edit(message_id, text)
+
 
 async def _emit(kind: str, text: str, route: Optional[str] = None, ttl_ms: int = 0):
     target = route or ROUTE_MAP.get(kind, "logs")
@@ -133,4 +136,12 @@ async def _emit(kind: str, text: str, route: Optional[str] = None, ttl_ms: int =
     except Exception as e:
         print(f"[DISPATCHER][ERR] kind={kind} route={target} -> {e}", flush=True)
 
-__all__ = ["emit", "emit_once", "flush_boot_queue", "send", "configure_channels", "dc"]
+__all__ = [
+    "emit",
+    "emit_once",
+    "flush_boot_queue",
+    "send",
+    "edit",
+    "configure_channels",
+    "dc",
+]


### PR DESCRIPTION
## Summary
- implement boot queue and channel routing in dispatcher with edit API
- expose minimal Discord adapter with send/edit/upsert/edit_trade_card helpers
- parse list env vars robustly and wire channel mapping from settings

## Testing
- `python -m py_compile ftm2/notify/dispatcher.py ftm2/notify/discord_bot.py ftm2/app.py ftm2/config/settings.py ftm2/exchange/streams_market.py ftm2/exchange/streams_user.py ftm2/trade/order_router.py ftm2/account/leverage_sync.py`
- ⚠️ `python run_ftm2.py` *(missing API key header)*

------
https://chatgpt.com/codex/tasks/task_e_68b137b03c70832d89e91f832384cdce