### PR TITLE
fix: stabilize notification dispatcher and Discord adapter

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -55,6 +55,30 @@ from ftm2 import strategy as ST
 
 CFG = load_env_chain()
 
+
+def _has_keys() -> bool:
+    return all(
+        [
+            any(
+                [
+                    getattr(CFG, "BINANCE_API_KEY", None),
+                    os.getenv("BINANCE_FAPI_KEY"),
+                    os.getenv("BINANCE_API_KEY"),
+                    os.getenv("APIKEY"),
+                ]
+            ),
+            any(
+                [
+                    getattr(CFG, "BINANCE_API_SECRET", None),
+                    os.getenv("BINANCE_FAPI_SECRET"),
+                    os.getenv("BINANCE_API_SECRET"),
+                    os.getenv("APISECRET"),
+                ]
+            ),
+        ]
+    )
+
+
 # [ANCHOR:DISPATCHER_BOOTSTRAP]
 
 
@@ -207,22 +231,29 @@ async def on_market(msg):
 
 
 async def main():
-    await notify.flush_boot_queue()
-    print(f"[FTM2][BOOT_ENV_SUMMARY] MODE={CFG.MODE}, SYMBOLS={CFG.SYMBOLS}, INTERVAL={CFG.INTERVAL}")
-    print(f"[FTM2] APIKEY={(CFG.BINANCE_API_KEY[:4] + '…') if CFG.BINANCE_API_KEY else 'EMPTY'}")
     notify.configure_channels({
-        "signals": "signals",
-        "trades": "trades",
-        "logs": "logs",
+        "signals": CFG.CHANNEL_SIGNALS,
+        "trades": CFG.CHANNEL_TRADES,
+        "logs": CFG.CHANNEL_LOGS,
     })
-    fbq = getattr(notify, "flush_boot_queue", None)
-    if fbq:
-        if inspect.iscoroutinefunction(fbq):
-            await fbq()
-        else:
-            fbq()
+    await notify.flush_boot_queue()
+    has_keys = _has_keys()
+    if not has_keys:
+        notify.emit_once(
+            "boot_no_keys",
+            "error",
+            "🚫 API 키가 없습니다. 분석/차트만 동작하고 주문/계정 기능은 꺼집니다.",
+            60_000,
+        )
+
+    print(
+        f"[FTM2][BOOT_ENV_SUMMARY] MODE={CFG.MODE}, SYMBOLS={CFG.SYMBOLS}, INTERVAL={CFG.INTERVAL}"
+    )
 
     bx = BinanceClient()
+    print(
+        f"[FTM2] APIKEY={(bx.api_key[:4] + '…') if getattr(bx, 'api_key', None) else 'EMPTY'}"
+    )
     t = bx.server_time()
     print(f"[FTM2] serverTime={t.get('serverTime')} REST_BASE OK")
     info = bx.load_exchange_info()
@@ -264,12 +295,13 @@ async def main():
     div = DivergenceMonitor(CFG.MAX_DIVERGENCE_BPS)
     MS.DIVERGENCE = div
 
-    for sym in CFG.SYMBOLS:
-        mode = CFG.MARGIN_MODE_OVERRIDE.get(sym, CFG.MARGIN_MODE_DEFAULT).upper()
-        lev = int(CFG.LEVERAGE_OVERRIDE.get(sym, CFG.LEVERAGE_DEFAULT))
-        await enforce_leverage_and_margin(
-            bx, sym, leverage=lev, margin_type=mode, notify=notify
-        )
+    if has_keys:
+        for sym in CFG.SYMBOLS:
+            mode = CFG.MARGIN_MODE_OVERRIDE.get(sym, CFG.MARGIN_MODE_DEFAULT).upper()
+            lev = int(CFG.LEVERAGE_OVERRIDE.get(sym, CFG.LEVERAGE_DEFAULT))
+            await enforce_leverage_and_margin(
+                bx, sym, leverage=lev, margin_type=mode, notify=notify
+            )
 
     def _notify(text):
         try:
@@ -388,8 +420,13 @@ async def main():
             trend_state=snap.trend_state,
         )
 
-    tasks.append(asyncio.create_task(run_analysis_loop(CFG, CFG.SYMBOLS, market_cache, div, on_snapshot)))
-    tasks.append(asyncio.create_task(INTQ.run()))
+    tasks.append(
+        asyncio.create_task(
+            run_analysis_loop(CFG, CFG.SYMBOLS, market_cache, div, on_snapshot)
+        )
+    )
+    if has_keys:
+        tasks.append(asyncio.create_task(INTQ.run()))
     tasks.append(asyncio.create_task(run_chart_janitor(CFG)))
 
     async def snapshot_daemon():

--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -10,7 +10,7 @@ try:
 except Exception as e:
     _bot = None
 
-async def _missing_async(*args, **kwargs):
+async def _missing(*args, **kwargs):
     raise RuntimeError("discord_bot API(send/edit/upsert)가 구현되어 있지 않습니다.")
 
 def _noop_use(*args, **kwargs):
@@ -18,9 +18,9 @@ def _noop_use(*args, **kwargs):
     return None
 
 dc = SimpleNamespace(
-    send=(getattr(_bot, "send", None) or _missing_async),
-    edit=(getattr(_bot, "edit", None) or _missing_async),
-    upsert=(getattr(_bot, "upsert", None) or _missing_async),
+    send=(getattr(_bot, "send", None) or _missing),
+    edit=(getattr(_bot, "edit", None) or _missing),
+    upsert=(getattr(_bot, "upsert", None) or _missing),
     use=(getattr(_bot, "use", None) or _noop_use),
 )
 
@@ -38,8 +38,8 @@ def _resolve_channel(key_or_name):
     if isinstance(k, str):
         if k in _CHANNELS:
             return _CHANNELS[k]
-        if k.startswith("#") and k in _CHANNELS:
-            return _CHANNELS[k]
+        if k.startswith("#") and k[1:] in _CHANNELS:
+            return _CHANNELS[k[1:]]
         if k.isdigit():
             return int(k)
     return k  # 마지막 방어
@@ -125,6 +125,9 @@ async def _send_impl(target, text: str):
 async def send(channel_key_or_name, text: str):
     return await _send_impl(channel_key_or_name, text)
 
+async def edit(message_id, text: str):
+    return await dc.edit(message_id, text)
+
 
 async def _emit(kind: str, text: str, route: Optional[str] = None, ttl_ms: int = 0):
     target = route or ROUTE_MAP.get(kind, "logs")
@@ -133,4 +136,12 @@ async def _emit(kind: str, text: str, route: Optional[str] = None, ttl_ms: int =
     except Exception as e:
         print(f"[DISPATCHER][ERR] kind={kind} route={target} -> {e}", flush=True)
 
-__all__ = ["emit", "emit_once", "flush_boot_queue", "send", "configure_channels", "dc"]
+__all__ = [
+    "emit",
+    "emit_once",
+    "flush_boot_queue",
+    "send",
+    "edit",
+    "configure_channels",
+    "dc",
+]


### PR DESCRIPTION
## Summary
- implement boot queue and channel routing in dispatcher with edit API
- expose minimal Discord adapter with send/edit/upsert/edit_trade_card helpers
- parse list env vars robustly and wire channel mapping from settings
- allow startup without Binance API keys, warning and skipping private setup

## Testing
- `python -m py_compile ftm2/notify/dispatcher.py ftm2/notify/discord_bot.py ftm2/app.py ftm2/config/settings.py ftm2/exchange/streams_market.py ftm2/exchange/streams_user.py ftm2/trade/order_router.py ftm2/account/leverage_sync.py ftm2/exchange/binance_client.py`
- ⚠️ `SMOKE_SECONDS=1 python run_ftm2.py` *(403 Forbidden via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b137b03c70832d89e91f832384cdce