### PR TITLE
feat: guard margin mode & safe dispatch

### DIFF
--- a/ftm2/notify/dispatcher.py
+++ b/ftm2/notify/dispatcher.py
@@ -17,6 +17,12 @@ def _noop_use(*args, **kwargs):
     # 예전 코드 호환: dispatcher.dc.use(...) 호출이 남아있어도 무해하게 처리
     return None
 
+# [ANCHOR:NOTIFY_DISPATCH]
+async def maybe_await(x):
+    if inspect.isawaitable(x):
+        return await x
+    return x
+
 dc = SimpleNamespace(
     send=(getattr(_bot, "send", None) or _missing),
     edit=(getattr(_bot, "edit", None) or _missing),
@@ -120,13 +126,13 @@ ROUTE_MAP = {
 # ==== 내부 전송(재귀 금지: 반드시 dc.send만 호출) ====
 async def _send_impl(target, text: str):
     chan = _resolve_channel(target)
-    return await dc.send(chan, text)
+    return await maybe_await(dc.send(chan, text))
 
 async def send(channel_key_or_name, text: str):
     return await _send_impl(channel_key_or_name, text)
 
 async def edit(message_id, text: str):
-    return await dc.edit(message_id, text)
+    return await maybe_await(dc.edit(message_id, text))
 
 
 async def _emit(kind: str, text: str, route: Optional[str] = None, ttl_ms: int = 0):

--- a/ftm2/trade/order_router.py
+++ b/ftm2/trade/order_router.py
@@ -59,7 +59,7 @@ class OrderRouter:
             await self.notify.emit(
                 "gate_skip", f"📡 {sym} 티켓없음 → 진입 금지", ttl_ms=120_000
             )
-            return False
+            return False  # [ANCHOR:INTENT_GATE]
 
         # 1) 사이징
         qty = self.sizer.size_entry(sym, tk, account=self.account.snapshot())


### PR DESCRIPTION
## Summary
- add safe margin mode helper and robust trade card rendering
- extend PositionState with margin metadata and auto-fallback
- wrap dispatcher sends with maybe_await to ignore non-awaitables
- enforce ticket gate early return in order router

## Testing
- `python -m py_compile FTM/ftm2/notify/cards.py FTM/ftm2/trade/position_tracker.py FTM/ftm2/notify/dispatcher.py FTM/ftm2/trade/order_router.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b13e5fe07c832d98ce2c6b6fdd9b16